### PR TITLE
Add healthchecks for Prometheus and Grafana

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -99,6 +99,12 @@ services:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
     ports:
       - "${PROMETHEUS_PORT:-9090}:9090"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9090/-/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
     networks: [chs_net]
 
   loki:
@@ -142,9 +148,15 @@ services:
       - ./grafana/provisioning:/etc/grafana/provisioning
     ports:
       - "${GRAFANA_PORT:-3000}:3000"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
     depends_on:
       prometheus:
-        condition: service_started
+        condition: service_healthy
       loki:
         condition: service_healthy
     networks: [chs_net]


### PR DESCRIPTION
## Summary
- add healthchecks for Prometheus and Grafana services
- wait for Prometheus to be healthy before starting Grafana

## Testing
- `pytest infra/tests`

------
https://chatgpt.com/codex/tasks/task_e_68aeccb0cba4832bb5d73b93d3e6152b