### PR TITLE
infra(prometheus): minimal scrape (self + loki) to avoid red targets

### DIFF
--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -9,19 +9,4 @@ scrape_configs:
 
   - job_name: loki
     static_configs:
-          - targets: [ 'loki:3100' ]
-
-  # Platzhalter: API-Service (sobald vorhanden)
-  #- job_name: api
-  #  static_configs:
-  #    - targets: ['api:8080']
-
-  # Platzhalter: ML-Serving (sobald vorhanden)
-  #- job_name: ml
-  #  static_configs:
-  #    - targets: ['ml:8000']
-
-  # Optional: MLflow (hat nicht nativ Prometheus, aber reverse-proxy/expoter möglich)
-  #- job_name: mlflow
-  #  static_configs:
-  #    - targets: ['mlflow:5000']
+      - targets: ['loki:3100']


### PR DESCRIPTION
## Summary
- limit Prometheus scraping to itself and Loki to avoid red targets

## Testing
- `pytest infra/tests`

------
https://chatgpt.com/codex/tasks/task_e_68aed017dac4832bb244f122f827e654