### PR TITLE
Load .env for monitoring tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,15 +21,16 @@ logs: ## Tail logs
 	@docker compose -f infra/docker-compose.yml --env-file $(ENV) logs -f --tail=200
 
 ps: ## Show processes
-        @docker compose -f infra/docker-compose.yml --env-file $(ENV) ps
+	@docker compose -f infra/docker-compose.yml --env-file $(ENV) ps
 
 status: ## Print endpoints
-        @echo "Grafana:   http://localhost:3000 (admin:$GRAFANA_USER)"
-        @echo "Prometheus:http://localhost:9090"
-        @echo "Loki:      http://localhost:3100"
-        @echo "MinIO:     http://localhost:9001 (console)"
-        @echo "MLflow:    http://localhost:5000"
-        @echo "Postgres:  localhost:5432 (db=$POSTGRES_DB user=$POSTGRES_USER)"
+	@echo "Grafana:   http://localhost:3000 (admin:$GRAFANA_USER)"
+	@echo "Prometheus:http://localhost:9090"
+	@echo "Loki:      http://localhost:3100"
+	@echo "MinIO:     http://localhost:9001 (console)"
+	@echo "MLflow:    http://localhost:5000"
+	@echo "Postgres:  localhost:5432 (db=$POSTGRES_DB user=$POSTGRES_USER)"
 
-test: ## Run monitoring connectivity tests
-        @pytest infra/tests
+test: ## Run monitoring checks
+	python3 -m pip install -r infra/tests/requirements.txt
+	pytest infra/tests -q

--- a/infra/tests/requirements.txt
+++ b/infra/tests/requirements.txt
@@ -1,1 +1,3 @@
+requests
+python-dotenv
 pytest

--- a/infra/tests/test_monitoring.py
+++ b/infra/tests/test_monitoring.py
@@ -1,4 +1,8 @@
-import os
+import os, pathlib
+from dotenv import load_dotenv
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+load_dotenv(ROOT / ".env", override=True)
+
 import logging
 import urllib.request
 import urllib.error


### PR DESCRIPTION
## Summary
- Load Grafana credentials from repo root `.env` in monitoring tests
- Add requests, python-dotenv and pytest to test requirements
- Provide `make test` target to install deps and run monitoring checks

## Testing
- `make test` *(fails: Could not find a version that satisfies the requirement requests)*
- `pytest infra/tests -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68aed01dcedc832b95f603d9bd853232