### PR TITLE
infra(grafana): provision ChessApp overview dashboard (Prometheus+Loki)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ## Observability
 - **Prometheus** scrapt (zunächst) Prometheus selbst – später `api:8080`, `ml:8000`, `mlflow`.
 - **Loki + Promtail** sammeln Docker‑Logs aller Services (Labels: `container`, `service`).
-- **Grafana** hat fertige Datasources (Prometheus, Loki). Dashboards folgen in einem späteren PR.
+- **Grafana** hat fertige Datasources (Prometheus, Loki). Dashboards: Grafana → Dashboards → Ordner "ChessApp" → "ChessApp – Overview".
 
 ## Grafana / Explore
 

--- a/infra/grafana/provisioning/dashboards/dashboards.yml
+++ b/infra/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+providers:
+  - name: 'chs-dashboards'
+    orgId: 1
+    folder: 'ChessApp'
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    options:
+      path: /etc/grafana/provisioning/dashboards/json

--- a/infra/grafana/provisioning/dashboards/json/chessapp-overview.json
+++ b/infra/grafana/provisioning/dashboards/json/chessapp-overview.json
@@ -1,0 +1,42 @@
+{
+  "id": null,
+  "uid": "chs-overview",
+  "title": "ChessApp – Overview",
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "10s",
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Ingest Jobs (chs_ingest_jobs_total)",
+      "gridPos": {"x":0,"y":0,"w":12,"h":8},
+      "targets": [
+        {
+          "datasource": {"type":"prometheus","uid":"prometheus"},
+          "expr": "chs_ingest_jobs_total",
+          "legendFormat": "{{application}}/{{component}} ({{username}})"
+        }
+      ]
+    },
+    {
+      "type": "logs",
+      "title": "API Logs (Loki)",
+      "gridPos": {"x":0,"y":8,"w":24,"h":12},
+      "options": {
+        "showLabels": true,
+        "showTime": true,
+        "dedupStrategy": "none",
+        "prettifyLogMessage": true,
+        "enableLogDetails": true
+      },
+      "targets": [
+        {
+          "datasource": {"type":"loki","uid":"loki"},
+          "expr": "{service=\"api\"} | json",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- provision Grafana to auto-load dashboards from `infra/grafana/provisioning/dashboards/json`
- add minimal "ChessApp – Overview" dashboard with Prometheus timeseries and Loki logs panels
- document dashboard path in README

## Testing
- `make test` *(fails: Could not find a version that satisfies the requirement requests (403 Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_68af16c88330832baa12323a1f6567ba