### PR TITLE
api(dataset): add dataset create/list/get with metrics, logs and MinIO manifest upload

### DIFF
--- a/api/api-app/pom.xml
+++ b/api/api-app/pom.xml
@@ -29,6 +29,11 @@
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>${aws.sdk.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.7.0</version>

--- a/api/api-app/src/main/java/com/chessapp/api/config/ObservabilityConfig.java
+++ b/api/api-app/src/main/java/com/chessapp/api/config/ObservabilityConfig.java
@@ -1,9 +1,13 @@
 package com.chessapp.api.config;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
 
@@ -18,5 +22,17 @@ public class ObservabilityConfig {
                 "component", "api",
                 "username",  defaultUser
         );
+    }
+
+    @Bean
+    public Counter datasetBuildCounter(MeterRegistry registry) {
+        return Counter.builder("chs_dataset_build_total").register(registry);
+    }
+
+    @Bean
+    public AtomicLong datasetRowsGauge(MeterRegistry registry) {
+        AtomicLong value = new AtomicLong(0);
+        Gauge.builder("chs_dataset_rows", value, AtomicLong::get).register(registry);
+        return value;
     }
 }

--- a/api/api-app/src/main/java/com/chessapp/api/config/S3Config.java
+++ b/api/api-app/src/main/java/com/chessapp/api/config/S3Config.java
@@ -1,0 +1,27 @@
+package com.chessapp.api.config;
+
+import java.net.URI;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Bean
+    public S3Client s3Client(@Value("${ML_S3_ENDPOINT:http://localhost:9000}") String endpoint,
+                             @Value("${AWS_REGION:us-east-1}") String region) {
+        return S3Client.builder()
+                .endpointOverride(URI.create(endpoint))
+                .region(Region.of(region))
+                .serviceConfiguration(S3Configuration.builder()
+                        .pathStyleAccessEnabled(true)
+                        .build())
+                .build();
+    }
+}

--- a/api/api-app/src/main/java/com/chessapp/api/web/DatasetController.java
+++ b/api/api-app/src/main/java/com/chessapp/api/web/DatasetController.java
@@ -1,0 +1,48 @@
+package com.chessapp.api.web;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.chessapp.api.service.DatasetService;
+import com.chessapp.api.service.dto.DatasetCreateRequest;
+import com.chessapp.api.service.dto.DatasetResponse;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/v1/datasets")
+public class DatasetController {
+
+    private final DatasetService datasetService;
+
+    public DatasetController(DatasetService datasetService) {
+        this.datasetService = datasetService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public DatasetResponse create(@Valid @RequestBody DatasetCreateRequest request) {
+        return datasetService.create(request);
+    }
+
+    @GetMapping
+    public List<DatasetResponse> list(@RequestParam(defaultValue = "50") int limit,
+                                      @RequestParam(defaultValue = "0") int offset) {
+        return datasetService.list(limit, offset);
+    }
+
+    @GetMapping("/{id}")
+    public DatasetResponse get(@PathVariable UUID id) {
+        return datasetService.get(id);
+    }
+}

--- a/api/api-service/pom.xml
+++ b/api/api-service/pom.xml
@@ -25,5 +25,10 @@
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>${aws.sdk.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/api/api-service/src/main/java/com/chessapp/api/service/DatasetMapper.java
+++ b/api/api-service/src/main/java/com/chessapp/api/service/DatasetMapper.java
@@ -1,0 +1,17 @@
+package com.chessapp.api.service;
+
+import com.chessapp.api.domain.entity.Dataset;
+import com.chessapp.api.service.dto.DatasetResponse;
+
+public class DatasetMapper {
+    public static DatasetResponse toDto(Dataset dataset) {
+        return new DatasetResponse(
+                dataset.getId(),
+                dataset.getName(),
+                dataset.getVersion(),
+                dataset.getSizeRows(),
+                dataset.getLocationUri(),
+                dataset.getCreatedAt()
+        );
+    }
+}

--- a/api/api-service/src/main/java/com/chessapp/api/service/DatasetService.java
+++ b/api/api-service/src/main/java/com/chessapp/api/service/DatasetService.java
@@ -1,0 +1,115 @@
+package com.chessapp.api.service;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.chessapp.api.domain.entity.Dataset;
+import com.chessapp.api.domain.repo.DatasetRepository;
+import com.chessapp.api.service.dto.DatasetCreateRequest;
+import com.chessapp.api.service.dto.DatasetResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.micrometer.core.instrument.Counter;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Service
+public class DatasetService {
+
+    private static final Logger log = LoggerFactory.getLogger(DatasetService.class);
+
+    private final DatasetRepository datasetRepository;
+    private final S3Client s3Client;
+    private final ObjectMapper objectMapper;
+    private final Counter datasetBuildCounter;
+    private final AtomicLong datasetRowsGauge;
+
+    public DatasetService(DatasetRepository datasetRepository,
+                          S3Client s3Client,
+                          ObjectMapper objectMapper,
+                          Counter datasetBuildCounter,
+                          AtomicLong datasetRowsGauge) {
+        this.datasetRepository = datasetRepository;
+        this.s3Client = s3Client;
+        this.objectMapper = objectMapper;
+        this.datasetBuildCounter = datasetBuildCounter;
+        this.datasetRowsGauge = datasetRowsGauge;
+    }
+
+    @Transactional
+    public DatasetResponse create(DatasetCreateRequest req) {
+        UUID id = UUID.randomUUID();
+        Dataset d = new Dataset();
+        d.setId(id);
+        d.setName(req.getName());
+        d.setVersion(req.getVersion());
+        d.setFilter(req.getFilter());
+        d.setSplit(req.getSplit());
+        long rows = req.getSizeRows() != null ? req.getSizeRows() : 0L;
+        d.setSizeRows(rows);
+        d.setCreatedAt(Instant.now());
+        d.setLocationUri("s3://datasets/" + id + "/");
+        datasetRepository.save(d);
+
+        Map<String, Object> manifest = new LinkedHashMap<>();
+        manifest.put("id", id.toString());
+        manifest.put("name", d.getName());
+        manifest.put("version", d.getVersion());
+        manifest.put("filter", d.getFilter());
+        manifest.put("split", d.getSplit());
+        manifest.put("createdAt", d.getCreatedAt());
+        manifest.put("username", MDC.get("username"));
+
+        try {
+            String json = objectMapper.writeValueAsString(manifest);
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket("datasets")
+                    .key(id + "/manifest.json")
+                    .contentType("application/json")
+                    .build();
+            s3Client.putObject(request, RequestBody.fromString(json));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to upload manifest", e);
+        }
+
+        datasetBuildCounter.increment();
+        if (req.getSizeRows() != null) {
+            datasetRowsGauge.set(req.getSizeRows());
+        }
+
+        try (MDC.MDCCloseable c1 = MDC.putCloseable("dataset_id", id.toString());
+             MDC.MDCCloseable c2 = MDC.putCloseable("event", "dataset.created");
+             MDC.MDCCloseable c3 = MDC.putCloseable("component", "dataset")) {
+            log.info("dataset created");
+        }
+
+        return DatasetMapper.toDto(d);
+    }
+
+    @Transactional(readOnly = true)
+    public List<DatasetResponse> list(int limit, int offset) {
+        return datasetRepository.findAll(PageRequest.of(offset / limit, limit))
+                .stream()
+                .map(DatasetMapper::toDto)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public DatasetResponse get(UUID id) {
+        return datasetRepository.findById(id)
+                .map(DatasetMapper::toDto)
+                .orElseThrow();
+    }
+}

--- a/api/api-service/src/main/java/com/chessapp/api/service/dto/DatasetCreateRequest.java
+++ b/api/api-service/src/main/java/com/chessapp/api/service/dto/DatasetCreateRequest.java
@@ -1,0 +1,25 @@
+package com.chessapp.api.service.dto;
+
+import java.util.Map;
+
+public class DatasetCreateRequest {
+    private String name;
+    private String version;
+    private Map<String, Object> filter;
+    private Map<String, Object> split;
+    private Long sizeRows;
+
+    public DatasetCreateRequest() {
+    }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getVersion() { return version; }
+    public void setVersion(String version) { this.version = version; }
+    public Map<String, Object> getFilter() { return filter; }
+    public void setFilter(Map<String, Object> filter) { this.filter = filter; }
+    public Map<String, Object> getSplit() { return split; }
+    public void setSplit(Map<String, Object> split) { this.split = split; }
+    public Long getSizeRows() { return sizeRows; }
+    public void setSizeRows(Long sizeRows) { this.sizeRows = sizeRows; }
+}

--- a/api/api-service/src/main/java/com/chessapp/api/service/dto/DatasetResponse.java
+++ b/api/api-service/src/main/java/com/chessapp/api/service/dto/DatasetResponse.java
@@ -1,0 +1,38 @@
+package com.chessapp.api.service.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public class DatasetResponse {
+    private UUID id;
+    private String name;
+    private String version;
+    private Long sizeRows;
+    private String locationUri;
+    private Instant createdAt;
+
+    public DatasetResponse() {
+    }
+
+    public DatasetResponse(UUID id, String name, String version, Long sizeRows, String locationUri, Instant createdAt) {
+        this.id = id;
+        this.name = name;
+        this.version = version;
+        this.sizeRows = sizeRows;
+        this.locationUri = locationUri;
+        this.createdAt = createdAt;
+    }
+
+    public UUID getId() { return id; }
+    public void setId(UUID id) { this.id = id; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getVersion() { return version; }
+    public void setVersion(String version) { this.version = version; }
+    public Long getSizeRows() { return sizeRows; }
+    public void setSizeRows(Long sizeRows) { this.sizeRows = sizeRows; }
+    public String getLocationUri() { return locationUri; }
+    public void setLocationUri(String locationUri) { this.locationUri = locationUri; }
+    public Instant getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+}

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -24,5 +24,6 @@
         <springdoc.version>2.6.0</springdoc.version>
         <logstash.encoder.version>7.4</logstash.encoder.version>
         <hibernate.types.version>2.21.1</hibernate.types.version>
+        <aws.sdk.version>2.25.26</aws.sdk.version>
     </properties>
 </project>

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -211,6 +211,11 @@ services:
       SPRINGDOC_SWAGGER_UI_DISABLE_SWAGGER_DEFAULT_URL: "true"
       SPRINGDOC_GROUPS_ENABLED: "true"
       SPRINGDOC_CACHE_DISABLED: "false"
+      
+      AWS_ACCESS_KEY_ID: ${MINIO_ROOT_USER}
+      AWS_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD}
+      AWS_REGION: us-east-1
+      ML_S3_ENDPOINT: http://minio:9000
 
     depends_on:
       db:


### PR DESCRIPTION
## Summary
- add AWS S3 dependency and S3 client bean configured for MinIO
- implement dataset DTOs, service and controller with manifest upload, metrics and logging
- expose dataset metrics and configure compose environment for MinIO credentials

## Testing
- `mvn -q -f api/pom.xml -pl api-app -am test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.5 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68af16d2adcc832b935523a677010ea4