### PR TITLE
Add online chess.com ingest and S3 artifact writing

### DIFF
--- a/api/api-app/src/main/java/com/chessapp/api/ingest/service/ArtifactWriter.java
+++ b/api/api-app/src/main/java/com/chessapp/api/ingest/service/ArtifactWriter.java
@@ -1,0 +1,41 @@
+package com.chessapp.api.ingest.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.core.sync.RequestBody;
+
+@Component
+public class ArtifactWriter {
+    private final S3Client s3;
+    private final ObjectMapper om;
+    private final String logsBucket;
+    private final String reportsBucket;
+    private final String ingestPrefix;
+
+    public ArtifactWriter(S3Client s3, ObjectMapper om,
+                          @Value("${chess.ingest.s3.bucket.logs:logs}") String logsBucket,
+                          @Value("${chess.ingest.s3.bucket.reports:reports}") String reportsBucket,
+                          @Value("${chess.ingest.s3.prefix.ingest:ingest}") String ingestPrefix) {
+        this.s3 = s3; this.om = om;
+        this.logsBucket = logsBucket;
+        this.reportsBucket = reportsBucket;
+        this.ingestPrefix = ingestPrefix;
+    }
+
+    public String putJsonToLogs(String runId, String name, Object obj) throws Exception {
+        String key = ingestPrefix + "/" + runId + "/" + name;
+        byte[] data = om.writeValueAsBytes(obj);
+        s3.putObject(PutObjectRequest.builder().bucket(logsBucket).key(key).build(), RequestBody.fromBytes(data));
+        return "s3://" + logsBucket + "/" + key;
+    }
+
+    public String putReport(String runId, Object obj) throws Exception {
+        String key = ingestPrefix + "/" + runId + "/report.json";
+        byte[] data = om.writeValueAsBytes(obj);
+        s3.putObject(PutObjectRequest.builder().bucket(reportsBucket).key(key).build(), RequestBody.fromBytes(data));
+        return "s3://" + reportsBucket + "/" + key;
+    }
+}

--- a/api/api-app/src/main/java/com/chessapp/api/ingest/service/ChessComClient.java
+++ b/api/api-app/src/main/java/com/chessapp/api/ingest/service/ChessComClient.java
@@ -1,0 +1,56 @@
+package com.chessapp.api.ingest.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class ChessComClient {
+    private final WebClient client;
+    public ChessComClient(WebClient.Builder builder,
+                          @Value("${chess.ingest.baseUrl:https://api.chess.com}") String baseUrl) {
+        this.client = builder.baseUrl(baseUrl).build();
+    }
+
+    public Mono<List<String>> listArchives(String username) {
+        return client.get()
+            .uri("/pub/player/{u}/games/archives", username)
+            .retrieve()
+            .onStatus(HttpStatus::isError, r -> r.createException().flatMap(Mono::error))
+            .bodyToMono(JsonNode.class)
+            .map(n -> {
+                var arr = n.get("archives");
+                if (arr == null || !arr.isArray()) return List.<String>of();
+                return Flux.fromIterable(arr)
+                        .map(JsonNode::asText)
+                        .collectList()
+                        .block();
+            })
+            .retryBackoff(5, Duration.ofMillis(300), Duration.ofSeconds(3))
+            .timeout(Duration.ofSeconds(10));
+    }
+
+    public Flux<JsonNode> fetchMonth(String username, YearMonth ym) {
+        return client.get()
+            .uri("/pub/player/{u}/games/{y}/{m}", username, ym.getYear(), String.format("%02d", ym.getMonthValue()))
+            .retrieve()
+            .onStatus(HttpStatus::isError, r -> r.createException().flatMap(Mono::error))
+            .bodyToMono(JsonNode.class)
+            .flatMapMany(n -> {
+                var arr = n.get("games");
+                if (arr == null || !arr.isArray()) return Flux.empty();
+                return Flux.fromIterable(arr);
+            })
+            .retryBackoff(5, Duration.ofMillis(300), Duration.ofSeconds(3))
+            .timeout(Duration.ofSeconds(15));
+    }
+}

--- a/api/api-app/src/main/java/com/chessapp/api/ingest/service/S3Config.java
+++ b/api/api-app/src/main/java/com/chessapp/api/ingest/service/S3Config.java
@@ -1,0 +1,35 @@
+package com.chessapp.api.ingest.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.sync.RequestBody;
+import java.net.URI;
+
+@Configuration
+public class S3Config {
+    @Bean
+    S3Client s3Client(
+        @Value("${s3.endpoint:http://minio:9000}") String endpoint,
+        @Value("${s3.region:us-east-1}") String region,
+        @Value("${s3.accessKey:minioadmin}") String accessKey,
+        @Value("${s3.secretKey:minioadmin}") String secretKey
+    ) {
+        return S3Client.builder()
+            .httpClientBuilder(UrlConnectionHttpClient.builder())
+            .endpointOverride(URI.create(endpoint))
+            .region(Region.of(region))
+            .credentialsProvider(StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(accessKey, secretKey)))
+            .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
+            .overrideConfiguration(ClientOverrideConfiguration.builder().build())
+            .build();
+    }
+}


### PR DESCRIPTION
## Summary
- add ChessComClient for retrieving chess.com archives and monthly game data
- configure S3 client and implement ArtifactWriter for logs and reports
- extend IngestService with online ingestion path using ChessComClient and S3 report storage

## Testing
- ⚠️ `mvn -q -pl api-app -am test` (failed: Network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_68af78a687c0832b9bef5958965b1163