### PR TITLE
feat: add codex local environment

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "java",
+      "name": "API (Spring Boot - codex)",
+      "request": "launch",
+      "mainClass": "com.chessapp.api.ApiApplication",
+      "projectName": "api",
+      "vmArgs": "-Dspring.profiles.active=codex"
+    }
+  ],
+  "compounds": [
+    { "name": "Dev (Infra + API)", "configurations": ["API (Spring Boot - codex)"], "preLaunchTask": "infra:up" }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,14 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    { "label": "infra:up",   "type": "shell",
+      "command": "docker compose up -d db minio mlflow prometheus loki grafana" },
+    { "label": "infra:down", "type": "shell", "command": "docker compose down" },
+    { "label": "api:run (codex)", "type": "shell",
+      "command": "mvn -q -pl api spring-boot:run -Dspring-boot.run.profiles=codex" },
+    { "label": "frontend:dev (codex)", "type": "shell",
+      "command": "npm --prefix frontend run dev -- --mode codex" },
+    { "label": "ml:serve (codex)", "type": "shell",
+      "command": "uvicorn ml.app:app --reload --port 8001", "problemMatcher": [] }
+  ]
+}

--- a/api/api-app/src/main/resources/application-codex.yml
+++ b/api/api-app/src/main/resources/application-codex.yml
@@ -1,0 +1,27 @@
+spring:
+  profiles:
+    group:
+      codex: codex
+  datasource:
+    url: jdbc:postgresql://localhost:5432/chs
+    username: ${DB_USER:postgres}
+    password: ${DB_PASS:postgres}
+  jpa:
+    hibernate:
+      ddl-auto: validate
+server:
+  port: 8080
+management:
+  endpoints.web.exposure.include: "*"
+  metrics.tags:
+    application: api
+    component: api
+    username: M3NG00S3
+springdoc:
+  api-docs.path: /v3/api-docs
+  swagger-ui.path: /swagger-ui.html
+chs:
+  username-default: M3NG00S3
+logging:
+  level:
+    root: INFO

--- a/api/api-app/src/main/resources/logback-codex.xml
+++ b/api/api-app/src/main/resources/logback-codex.xml
@@ -1,0 +1,6 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder"/>
+  </appender>
+  <root level="INFO"><appender-ref ref="STDOUT"/></root>
+</configuration>

--- a/docs/CODEX-SETUP.md
+++ b/docs/CODEX-SETUP.md
@@ -1,0 +1,54 @@
+# Codex Local Environment
+
+Quick start for running the ChessApp components locally without touching existing Docker or CI configs.
+
+## Start
+
+```bash
+docker compose up -d db minio mlflow prometheus loki grafana
+mvn -q -pl api spring-boot:run -Dspring-boot.run.profiles=codex
+npm --prefix frontend run dev -- --mode codex
+uvicorn ml.app:app --reload --port 8001
+```
+
+## Stop
+
+```bash
+docker compose down
+```
+
+## Ports & Links
+
+- Swagger UI: <http://localhost:8080/swagger-ui.html>
+- Prometheus: <http://localhost:9090>
+- Grafana: <http://localhost:3000>
+- Loki: <http://localhost:3100>
+- MLflow: <http://localhost:5000>
+
+## Smoke tests
+
+```bash
+curl http://localhost:8080/actuator/health
+curl http://localhost:8080/v3/api-docs | jq '.openapi'
+curl http://localhost:8080/swagger-ui.html >/dev/null && echo "Swagger OK"
+```
+
+Example run (this environment lacked Docker and Maven network access):
+
+```text
+$ docker compose -f infra/docker-compose.yml up -d db minio mlflow prometheus loki grafana
+bash: command not found: docker
+
+$ mvn -q -f api/pom.xml -pl api-app spring-boot:run -Dspring-boot.run.profiles=codex
+[ERROR] [ERROR] Some problems were encountered while processing the POMs:
+[FATAL] Non-resolvable parent POM for com.chessapp:api:0.0.1-SNAPSHOT: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.5.5 (absent): Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable and 'parent.relativePath' points at no local POM @ line 4, column 13
+
+$ curl http://localhost:8080/actuator/health
+curl: (7) Failed to connect to localhost port 8080 after 0 ms: Couldn't connect to server
+```
+
+## Troubleshooting
+
+- Install and start Docker to run the infrastructure stack.
+- Ensure Maven has internet access to download dependencies.
+- Optional JSON logging: run the API with `-Dlogging.config=classpath:logback-codex.xml`.

--- a/frontend/.env.codex
+++ b/frontend/.env.codex
@@ -1,0 +1,2 @@
+VITE_API_URL=http://localhost:8080
+VITE_API_PREFIX=/v1

--- a/ml/.env.codex
+++ b/ml/.env.codex
@@ -1,0 +1,5 @@
+MLFLOW_TRACKING_URI=http://localhost:5000
+MINIO_ENDPOINT=http://localhost:9000
+MINIO_ACCESS_KEY=admin
+MINIO_SECRET_KEY=admin123
+MINIO_BUCKET=models


### PR DESCRIPTION
## Summary
- add codex profile and optional JSON logging for API
- add codex env files for frontend and ML
- add VS Code tasks/launch config and setup docs

## Testing
- `docker compose -f infra/docker-compose.yml up -d db minio mlflow prometheus loki grafana` *(command not found: docker)*
- `mvn -q -f api/pom.xml -pl api-app spring-boot:run -Dspring-boot.run.profiles=codex` *(Non-resolvable parent POM: network unreachable)*
- `curl http://localhost:8080/actuator/health` *(Failed to connect to localhost port 8080)*

------
https://chatgpt.com/codex/tasks/task_e_68b027d8d924832bac95d03b7225a102