### PR TITLE
feat: add codex http observability

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,11 +21,17 @@
       },
       "problemMatcher": []
     },
-    {
-    "label": "infra:down",
-    "type": "shell",
-    "command": "docker compose -f infra/docker-compose.yml down",
-    "options": { "cwd": "${workspaceFolder}" }
-  },
-  ]
-}
+      {
+        "label": "frontend:dev (codex)",
+        "type": "shell",
+        "command": "npm --prefix frontend run dev -- --mode codex",
+        "options": { "cwd": "${workspaceFolder}" }
+      },
+      {
+        "label": "infra:down",
+        "type": "shell",
+        "command": "docker compose -f infra/docker-compose.yml down",
+        "options": { "cwd": "${workspaceFolder}" }
+      }
+    ]
+  }

--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ Tipp: Label Browser nutzen und `service`/`container` auswählen.
 
 ## Ports
 - Grafana 3000 · Prometheus 9090 · Loki 3100 · MLflow 5000 · MinIO S3 9000 · MinIO Console 9001 · Postgres 5432
+
+## Lokales Codex-Profil
+
+Hinweise zum lokalen Entwicklungsprofil findest du in [docs/CODEX-SETUP.md](docs/CODEX-SETUP.md).

--- a/api/api-app/src/main/java/com/chessapp/api/codex/HttpMetricsFilter.java
+++ b/api/api-app/src/main/java/com/chessapp/api/codex/HttpMetricsFilter.java
@@ -1,0 +1,77 @@
+package com.chessapp.api.codex;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+@Component
+@Profile("codex")
+public class HttpMetricsFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(HttpMetricsFilter.class);
+
+    private final MeterRegistry registry;
+    private final String username;
+
+    public HttpMetricsFilter(MeterRegistry registry,
+                             @Value("${chs.default-username:M3NG00S3}") String username) {
+        this.registry = registry;
+        this.username = username;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String runId = UUID.randomUUID().toString();
+        MDC.put("run_id", runId);
+        MDC.put("component", "api");
+        MDC.put("username", username);
+        MDC.put("path", request.getRequestURI());
+
+        long start = System.currentTimeMillis();
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            long durationMs = System.currentTimeMillis() - start;
+            String status = String.valueOf(response.getStatus());
+
+            MDC.put("status", status);
+            MDC.put("duration_ms", String.valueOf(durationMs));
+
+            Counter.builder("chs_api_http_requests_total")
+                .tags("method", request.getMethod(),
+                      "path", request.getRequestURI(),
+                      "status", status)
+                .register(registry)
+                .increment();
+
+            Timer.builder("chs_api_http_latency_ms")
+                .tags("method", request.getMethod(),
+                      "path", request.getRequestURI(),
+                      "status", status)
+                .register(registry)
+                .record(durationMs, TimeUnit.MILLISECONDS);
+
+            log.info("request completed");
+            MDC.clear();
+        }
+    }
+}
+

--- a/api/api-app/src/main/resources/application-codex.yml
+++ b/api/api-app/src/main/resources/application-codex.yml
@@ -31,6 +31,7 @@ management:
     username: ${CHESS_USERNAME:M3NG00S3}
 
 logging:
+  config: classpath:logback-codex.xml
   level:
     root: INFO
     com.chessapp.api: INFO

--- a/docs/CODEX-SETUP.md
+++ b/docs/CODEX-SETUP.md
@@ -31,6 +31,7 @@ docker compose down
 curl http://localhost:8080/actuator/health
 curl http://localhost:8080/v3/api-docs | jq '.openapi'
 curl http://localhost:8080/swagger-ui.html >/dev/null && echo "Swagger OK"
+curl http://localhost:8080/actuator/prometheus | grep chs_api_http_requests_total
 ```
 
 Example run (this environment lacked Docker and Maven network access):


### PR DESCRIPTION
## Summary
- add codex http metrics filter recording request latency and counts
- enable JSON logging via logback-codex and document local codex profile
- extend VS Code tasks for codex development

## Testing
- `mvn -q -f api/api-app/pom.xml test` *(fails: Non-resolvable parent POM)*
- `mvn -f api/api-app/pom.xml spring-boot:run -Dspring-boot.run.profiles=codex` *(fails: Non-resolvable parent POM)*
- `curl http://localhost:8080/actuator/health` *(connection refused)*
- `curl http://localhost:8080/actuator/prometheus` *(connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b053a3a218832ba74e70b13c396ed9