### PR TITLE
Enable Prometheus metrics text export and integration test

### DIFF
--- a/api/api-app/src/main/resources/application-codex.yml
+++ b/api/api-app/src/main/resources/application-codex.yml
@@ -20,15 +20,25 @@ spring:
     allow-bean-definition-overriding: true   # für dev, löst den IngestService-Konflikt
 
 management:
-  endpoints.web.exposure.include: health,info,prometheus, env, metrics,beans,mappings, threaddump
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus,env,metrics,beans,mappings,threaddump
   endpoint:
     env:
       show-values: ALWAYS
-  endpoint.health.probes.enabled: true
-  metrics.tags:
-    application: api
-    component: api
-    username: ${CHESS_USERNAME:M3NG00S3}
+    health:
+      probes:
+        enabled: true
+  metrics:
+    tags:
+      application: api
+      component: api
+      username: ${CHESS_USERNAME:M3NG00S3}
+  prometheus:
+    metrics:
+      export:
+        enabled: true
 
 logging:
   config: classpath:logback-codex.xml

--- a/api/api-app/src/main/resources/application.yml
+++ b/api/api-app/src/main/resources/application.yml
@@ -16,15 +16,25 @@ spring:
     baseline-on-migrate: true
     baseline-version: 0
 management:
-  endpoints.web.exposure.include: health,info,prometheus, env, metrics,beans,mappings, threaddump
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus,env,metrics,beans,mappings,threaddump
   endpoint:
     env:
       show-values: ALWAYS
-  endpoint.health.probes.enabled: true
-  metrics.tags:
-    application: api
-    component: api
-    username: ${CHESS_USERNAME:M3NG00S3}
+    health:
+      probes:
+        enabled: true
+  metrics:
+    tags:
+      application: api
+      component: api
+      username: ${CHESS_USERNAME:M3NG00S3}
+  prometheus:
+    metrics:
+      export:
+        enabled: true
 logging:
   level:
     root: INFO

--- a/api/api-app/src/test/java/com/chessapp/api/it/PrometheusTextExportIT.java
+++ b/api/api-app/src/test/java/com/chessapp/api/it/PrometheusTextExportIT.java
@@ -1,0 +1,48 @@
+package com.chessapp.api.it;
+
+import com.chessapp.api.codex.CodexApplication;
+import com.chessapp.api.testutil.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(
+        classes = CodexApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {
+                "logging.config=classpath:logback-spring.xml",
+                "management.prometheus.metrics.export.enabled=true"
+        }
+)
+@ActiveProfiles("codex")
+class PrometheusTextExportIT extends AbstractIntegrationTest {
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    TestRestTemplate rest;
+
+    @Test
+    void prometheusEndpointExportsMetrics() {
+        String url = "http://localhost:" + port + "/actuator/prometheus";
+        ResponseEntity<String> resp = rest.getForEntity(url, String.class);
+        assertThat(resp.getStatusCode().value()).isEqualTo(200);
+        assertThat(resp.getHeaders().getFirst("Content-Type"))
+                .startsWith("text/plain; version=0.0.4");
+        String body = resp.getBody();
+        assertThat(body).isNotBlank();
+        Pattern pattern = Pattern.compile(
+                "^chs_ingest_games_total\\{[^}]*username=\"M3NG00S3\"[^}]*}.+$",
+                Pattern.MULTILINE);
+        assertThat(pattern.matcher(body).find()).isTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- expose Prometheus endpoint by enabling metrics export in application configs
- add integration test checking /actuator/prometheus text output

## Testing
- `mvn -f api/pom.xml -pl api-app -am test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b08ade9d3c832bba7797b329ad7e8b