### PR TITLE
feat(ml): FastAPI-Training-Skeleton inkl. MLflow/Prometheus/Loki

### DIFF
--- a/api/api-app/src/main/java/com/chessapp/api/training/api/TrainingController.java
+++ b/api/api-app/src/main/java/com/chessapp/api/training/api/TrainingController.java
@@ -1,0 +1,26 @@
+package com.chessapp.api.training.api;
+
+import com.chessapp.api.training.service.TrainingService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/v1/trainings")
+public class TrainingController {
+
+    private final TrainingService service;
+    public TrainingController(TrainingService service) { this.service = service; }
+
+    @PostMapping
+    public ResponseEntity<Map<String, Object>> start(@RequestBody TrainingStartRequest req) {
+        UUID runId = service.startTraining(req);
+        return ResponseEntity.accepted().body(Map.of("runId", runId.toString()));
+    }
+
+    @GetMapping("/{runId}")
+    public ResponseEntity<Map<String, Object>> status(@PathVariable UUID runId) {
+        return ResponseEntity.ok(service.getStatus(runId));
+    }
+}

--- a/api/api-app/src/main/java/com/chessapp/api/training/api/TrainingStartRequest.java
+++ b/api/api-app/src/main/java/com/chessapp/api/training/api/TrainingStartRequest.java
@@ -1,0 +1,10 @@
+package com.chessapp.api.training.api;
+
+import java.util.Map;
+import java.util.UUID;
+
+public record TrainingStartRequest(
+        UUID datasetId,
+        String preset,
+        Map<String, Object> params
+) {}

--- a/api/api-app/src/main/java/com/chessapp/api/training/service/MlClient.java
+++ b/api/api-app/src/main/java/com/chessapp/api/training/service/MlClient.java
@@ -1,0 +1,9 @@
+package com.chessapp.api.training.service;
+
+import java.util.Map;
+import java.util.UUID;
+
+public interface MlClient {
+    void postTrain(UUID runId, UUID datasetId, Map<String, Object> params);
+    Map<String, Object> getRun(UUID runId);
+}

--- a/api/api-app/src/main/java/com/chessapp/api/training/service/MlClientWeb.java
+++ b/api/api-app/src/main/java/com/chessapp/api/training/service/MlClientWeb.java
@@ -1,0 +1,45 @@
+package com.chessapp.api.training.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Component
+public class MlClientWeb implements MlClient {
+
+    private final WebClient web;
+
+    public MlClientWeb(@Value("${chs.ml.base-url:http://ml:8000}") String baseUrl) {
+        this.web = WebClient.builder().baseUrl(baseUrl).build();
+    }
+
+    @Override
+    public void postTrain(UUID runId, UUID datasetId, Map<String, Object> params) {
+        Map<String, Object> body = Map.of(
+                "runId", runId.toString(),
+                "datasetId", datasetId != null ? datasetId.toString() : null,
+                "epochs", params != null && params.get("epochs") != null ? (Integer) params.get("epochs") : 10,
+                "stepsPerEpoch", params != null && params.get("stepsPerEpoch") != null ? (Integer) params.get("stepsPerEpoch") : 50,
+                "lr", params != null && params.get("lr") != null ? ((Number) params.get("lr")).doubleValue() : 1e-3
+        );
+        web.post().uri("/train")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(Map.class)
+                .block();
+    }
+
+    @Override
+    public Map<String, Object> getRun(UUID runId) {
+        return web.get().uri("/runs/{id}", runId.toString())
+                .retrieve()
+                .bodyToMono(Map.class)
+                .blockOptional()
+                .orElse(Map.of("status","unknown"));
+    }
+}

--- a/api/api-app/src/main/java/com/chessapp/api/training/service/TrainingService.java
+++ b/api/api-app/src/main/java/com/chessapp/api/training/service/TrainingService.java
@@ -1,0 +1,73 @@
+package com.chessapp.api.training.service;
+
+import com.chessapp.api.domain.entity.TrainingRun;
+import com.chessapp.api.domain.entity.TrainingStatus;
+import com.chessapp.api.domain.repo.TrainingRunRepository;
+import com.chessapp.api.training.api.TrainingStartRequest;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.*;
+
+@Service
+public class TrainingService {
+
+    private final TrainingRunRepository repo;
+    private final MlClient mlClient;
+    private final Counter runsTotal;
+
+    public TrainingService(TrainingRunRepository repo, MlClient mlClient, MeterRegistry registry) {
+        this.repo = repo;
+        this.mlClient = mlClient;
+        this.runsTotal = Counter.builder("chs_training_runs_total").register(registry);
+    }
+
+    @Transactional
+    public UUID startTraining(TrainingStartRequest req) {
+        UUID runId = UUID.randomUUID();
+        try (MDC.MDCCloseable r = MDC.putCloseable("run_id", runId.toString())) {
+            TrainingRun tr = new TrainingRun();
+            tr.setId(runId);
+            tr.setDatasetId(req.datasetId());
+            tr.setParams(Optional.ofNullable(req.params()).orElseGet(Map::of));
+            tr.setStatus(TrainingStatus.QUEUED);
+            repo.save(tr);
+
+            mlClient.postTrain(runId, req.datasetId(), req.params());
+
+            tr.setStatus(TrainingStatus.RUNNING);
+            tr.setStartedAt(Instant.now());
+            repo.save(tr);
+
+            runsTotal.increment();
+            return runId;
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public Map<String, Object> getStatus(UUID runId) {
+        TrainingRun tr = repo.findById(runId).orElse(null);
+        Map<String, Object> ml = Map.of();
+        try { ml = mlClient.getRun(runId); } catch (Exception ignored) {}
+
+        Map<String, Object> out = new LinkedHashMap<>();
+        if (tr != null) {
+            out.put("runId", tr.getId().toString());
+            out.put("status", tr.getStatus().name().toLowerCase());
+            out.put("startedAt", tr.getStartedAt());
+            out.put("finishedAt", tr.getFinishedAt());
+            out.put("metrics", tr.getMetrics());
+            out.put("artifactUris", Optional.ofNullable(tr.getLogsUri()).map(u -> Map.of("logs", u)).orElseGet(Map::of));
+        }
+        if (ml.get("status") != null) out.put("status", String.valueOf(ml.get("status")));
+        if (ml.get("metrics") instanceof Map<?,?> m) out.put("metrics", m);
+        if (ml.get("artifactUris") instanceof Map<?,?> a) out.put("artifactUris", a);
+        if (ml.get("startedAt") != null) out.put("startedAt", ml.get("startedAt"));
+        if (ml.get("finishedAt") != null) out.put("finishedAt", ml.get("finishedAt"));
+        return out;
+    }
+}

--- a/api/api-app/src/main/resources/application.yml
+++ b/api/api-app/src/main/resources/application.yml
@@ -34,8 +34,12 @@ logging:
     root: INFO
     com.chessapp.api: INFO
     org.flywaydb: DEBUG
+  pattern:
+    console: "{\"ts\":\"%d{yyyy-MM-dd'T'HH:mm:ss.SSSX}\",\"level\":\"%p\",\"logger\":\"%c{1}\",\"msg\":%m,\"run_id\":\"%X{run_id}\",\"component\":\"training\"}%n"
 chs:
   default-username: ${CHESS_USERNAME:M3NG00S3}
+  ml:
+    base-url: ${ML_BASE_URL:http://ml:8000}
 chess:
   ingest:
     baseUrl: https://api.chess.com

--- a/api/api-app/src/test/java/com/chessapp/api/training/TrainingControllerIT.java
+++ b/api/api-app/src/test/java/com/chessapp/api/training/TrainingControllerIT.java
@@ -1,0 +1,60 @@
+package com.chessapp.api.training;
+
+import com.chessapp.api.training.api.TrainingStartRequest;
+import com.chessapp.api.training.service.MlClient;
+import com.chessapp.api.training.service.TrainingService;
+import com.chessapp.api.testutil.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Map;
+import java.util.UUID;
+
+class TrainingControllerIT extends AbstractIntegrationTest {
+
+    @TestConfiguration
+    static class Cfg {
+        @Bean
+        MlClient fake() {
+            return new MlClient() {
+                @Override public void postTrain(UUID runId, UUID datasetId, Map<String,Object> params) { /* no-op */ }
+                @Override public Map<String, Object> getRun(UUID runId) {
+                    return Map.of("status","succeeded","metrics", Map.of("loss",0.1,"val_acc",0.9));
+                }
+            };
+        }
+    }
+
+    @Autowired
+    TrainingService service;
+
+    @Autowired
+    org.springframework.context.ApplicationContext ctx;
+
+    @Test
+    void start_and_status_ok() {
+        WebTestClient client = WebTestClient.bindToApplicationContext(ctx).build();
+
+        var req = new TrainingStartRequest(null, "policy_tiny", Map.of("epochs",2,"stepsPerEpoch",3,"lr",1e-3));
+        String runId = client.post().uri("/v1/trainings")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(req)
+                .exchange()
+                .expectStatus().isAccepted()
+                .expectBody()
+                .jsonPath("$.runId").value(String::valueOf);
+
+        client.get().uri("/v1/trainings/{id}", runId)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.status").isEqualTo("succeeded")
+                .jsonPath("$.metrics.loss").exists()
+                .jsonPath("$.metrics.val_acc").exists();
+    }
+}
+

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -178,6 +178,30 @@ services:
       loki:
         condition: service_healthy
     networks: [chs_net]
+  ml:
+    build:
+      context: ../
+      dockerfile: ml/Dockerfile
+    environment:
+      MLFLOW_TRACKING_URI: http://mlflow:5000
+      ML_S3_ENDPOINT: http://minio:9000
+      AWS_ACCESS_KEY_ID: ${MINIO_ROOT_USER}
+      AWS_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD}
+      AWS_REGION: us-east-1
+      DEFAULT_USERNAME: ${CHESS_USERNAME:-M3NG00S3}
+      ML_ARTIFACT_BUCKET: mlflow
+    depends_on:
+      - minio
+      - mlflow
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8000/health"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+    ports:
+      - "8000:8000"
+    networks: [ chs_net ]
+    restart: unless-stopped
   api:
     build:
       context: ..

--- a/infra/grafana/provisioning/dashboards/json/chessapp-overview.json
+++ b/infra/grafana/provisioning/dashboards/json/chessapp-overview.json
@@ -50,7 +50,7 @@
     {
       "type": "logs",
       "title": "API Logs (Loki)",
-      "gridPos": { "x": 0, "y": 16, "w": 24, "h": 12 },
+      "gridPos": { "x": 0, "y": 29, "w": 24, "h": 12 },
       "options": {
         "showLabels": true,
         "showTime": true,
@@ -63,6 +63,30 @@
           "expr": "{service=\"api\"} | json",
           "refId": "A"
         }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Training Loss (chs_training_loss)",
+      "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "chs_training_loss" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Val Accuracy (chs_training_val_accuracy)",
+      "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "chs_training_val_accuracy" }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Runs total (chs_training_runs_total)",
+      "gridPos": { "x": 0, "y": 24, "w": 6, "h": 5 },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(chs_training_runs_total)" }
       ]
     }
   ]

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -15,3 +15,7 @@ scrape_configs:
     metrics_path: /actuator/prometheus
     static_configs:
       - targets: ['api:8080']
+  - job_name: ml
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['ml:8000']

--- a/ml/Dockerfile
+++ b/ml/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+COPY ml/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY ml/app /app/app
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/ml/app/__init__.py
+++ b/ml/app/__init__.py
@@ -1,0 +1,1 @@
+# empty on purpose

--- a/ml/app/main.py
+++ b/ml/app/main.py
@@ -1,0 +1,197 @@
+import os, time, json, uuid, logging
+from datetime import datetime
+from typing import Optional, Dict, Any
+
+from fastapi import FastAPI, BackgroundTasks, HTTPException
+from pydantic import BaseModel, Field
+from prometheus_client import Counter, Gauge, Histogram, CollectorRegistry, CONTENT_TYPE_LATEST, generate_latest
+from starlette.responses import Response
+import mlflow
+
+try:
+    import boto3
+    from botocore.config import Config as BotoConfig
+except Exception:
+    boto3 = None
+
+# --- Config (ENV) ---
+ML_S3_ENDPOINT = os.getenv("ML_S3_ENDPOINT", "http://minio:9000")
+AWS_REGION = os.getenv("AWS_REGION", "us-east-1")
+AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID")
+AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY")
+MLFLOW_TRACKING_URI = os.getenv("MLFLOW_TRACKING_URI", "file:///tmp/mlruns")
+DEFAULT_USERNAME = os.getenv("DEFAULT_USERNAME", "M3NG00S3")
+ARTIFACT_BUCKET = os.getenv("ML_ARTIFACT_BUCKET", "mlflow")
+
+mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)
+
+# --- Logging (JSON) ---
+logger = logging.getLogger("ml")
+logger.setLevel(logging.INFO)
+handler = logging.StreamHandler()
+try:
+    from python_json_logger import jsonlogger
+    handler.setFormatter(jsonlogger.JsonFormatter())
+except Exception:
+    handler.setFormatter(logging.Formatter('%(message)s'))
+logger.handlers = [handler]
+
+def log_event(event: str, **extra):
+    payload = {"ts": datetime.utcnow().isoformat() + "Z", "event": event, "component": "training", "username": DEFAULT_USERNAME}
+    payload.update({k: v for k, v in extra.items() if v is not None})
+    logger.info(json.dumps(payload))
+
+# --- Prometheus registry/metrics ---
+registry = CollectorRegistry()
+
+RUNS_TOTAL = Counter("chs_training_runs_total", "Total training runs started",
+                     ["username", "component"], registry=registry)
+LOSS = Gauge("chs_training_loss", "Training loss (last step)",
+             ["run_id", "dataset_id", "username", "component"], registry=registry)
+VAL_ACC = Gauge("chs_training_val_accuracy", "Validation accuracy (last step)",
+                ["run_id", "dataset_id", "username", "component"], registry=registry)
+STEP_SEC = Histogram("chs_training_step_duration_seconds", "Per-step duration seconds",
+                     ["run_id", "dataset_id", "username", "component"], registry=registry)
+
+# --- In-memory run store (MVP) ---
+class RunState(BaseModel):
+    runId: str
+    datasetId: Optional[str] = None
+    status: str = "queued"
+    currentEpoch: int = 0
+    epochs: int = 10
+    stepsPerEpoch: int = 50
+    lr: float = 1e-3
+    metrics: Dict[str, float] = Field(default_factory=dict)
+    startedAt: Optional[str] = None
+    finishedAt: Optional[str] = None
+    artifactUris: Dict[str, str] = Field(default_factory=dict)
+    mlflowRunId: Optional[str] = None
+
+RUNS: Dict[str, RunState] = {}
+
+# --- Schemas ---
+class TrainRequest(BaseModel):
+    runName: Optional[str] = None
+    runId: Optional[str] = None
+    datasetId: Optional[str] = None
+    epochs: int = 10
+    stepsPerEpoch: int = 50
+    lr: float = 1e-3
+
+app = FastAPI(title="ChessApp ML", version="0.1")
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+@app.get("/metrics")
+def metrics():
+    data = generate_latest(registry)
+    return Response(data, media_type=CONTENT_TYPE_LATEST)
+
+@app.post("/train")
+def train(req: TrainRequest, bg: BackgroundTasks):
+    run_id = req.runId or str(uuid.uuid4())
+    if run_id in RUNS and RUNS[run_id].status in ("running", "queued"):
+        return {"runId": run_id}
+    state = RunState(
+        runId=run_id, datasetId=req.datasetId, status="running",
+        epochs=req.epochs, stepsPerEpoch=req.stepsPerEpoch, lr=req.lr,
+        startedAt=datetime.utcnow().isoformat()+"Z"
+    )
+    RUNS[run_id] = state
+    RUNS_TOTAL.labels(DEFAULT_USERNAME, "ml").inc()
+    log_event("training.started", run_id=run_id, dataset_id=req.datasetId, lr=req.lr, epochs=req.epochs)
+
+    bg.add_task(_training_loop, state, req.runName)
+    return {"runId": run_id}
+
+@app.get("/runs/{run_id}")
+def run_status(run_id: str):
+    state = RUNS.get(run_id)
+    if not state:
+        raise HTTPException(status_code=404, detail="Run not found")
+    return state
+
+# --- Helpers ---
+def _upload_artifacts(run_id: str, report: Dict[str, Any]) -> Dict[str, str]:
+    uris = {}
+    try:
+        best_bytes = b"DUMMY_WEIGHTS"
+        report_bytes = json.dumps(report, indent=2).encode("utf-8")
+
+        if boto3 and AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY:
+            s3 = boto3.client("s3",
+                endpoint_url=ML_S3_ENDPOINT,
+                aws_access_key_id=AWS_ACCESS_KEY_ID,
+                aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+                region_name=AWS_REGION,
+                config=BotoConfig(signature_version="s3v4"))
+            key_w = f"models/{run_id}/best.pt"
+            key_r = f"reports/{run_id}/training_report.json"
+            s3.put_object(Bucket=ARTIFACT_BUCKET, Key=key_w, Body=best_bytes, ContentType="application/octet-stream")
+            s3.put_object(Bucket=ARTIFACT_BUCKET, Key=key_r, Body=report_bytes, ContentType="application/json")
+            uris["weights"] = f"s3://{ARTIFACT_BUCKET}/{key_w}"
+            uris["report"] = f"s3://{ARTIFACT_BUCKET}/{key_r}"
+        else:
+            os.makedirs(f"/tmp/{run_id}", exist_ok=True)
+            with open(f"/tmp/{run_id}/best.pt","wb") as f: f.write(best_bytes)
+            with open(f"/tmp/{run_id}/training_report.json","wb") as f: f.write(report_bytes)
+            uris["weights"] = f"file:///tmp/{run_id}/best.pt"
+            uris["report"] = f"file:///tmp/{run_id}/training_report.json"
+    except Exception as e:
+        log_event("training.artifact_upload_failed", run_id=run_id, error=str(e))
+    return uris
+
+def _training_loop(state: RunState, run_name: Optional[str]):
+    labels = {"run_id": state.runId, "dataset_id": state.datasetId or "n/a", "username": DEFAULT_USERNAME, "component": "ml"}
+    mlflow_run_id = None
+    try:
+        mlflow.set_experiment("chessapp_training")
+        with mlflow.start_run(run_name=run_name or f"run-{state.runId}") as run:
+            mlflow_run_id = run.info.run_id
+            mlflow.log_params({"epochs": state.epochs, "steps_per_epoch": state.stepsPerEpoch, "lr": state.lr,
+                               "run_id": state.runId, "dataset_id": state.datasetId or ""})
+            mlflow.set_tags({"component":"training","run_id":state.runId,"username":DEFAULT_USERNAME})
+
+            loss, acc = 1.0, 0.1
+            for epoch in range(1, state.epochs + 1):
+                state.currentEpoch = epoch
+                for step in range(1, state.stepsPerEpoch + 1):
+                    t0 = time.perf_counter()
+                    loss = max(0.01, loss * 0.97)
+                    acc = min(0.999, acc + 0.005)
+
+                    state.metrics = {"loss": float(round(loss, 6)), "val_acc": float(round(acc, 6))}
+                    LOSS.labels(**labels).set(state.metrics["loss"])
+                    VAL_ACC.labels(**labels).set(state.metrics["val_acc"])
+                    dt = time.perf_counter() - t0
+                    STEP_SEC.labels(**labels).observe(dt)
+
+                    global_step = (epoch - 1) * state.stepsPerEpoch + step
+                    mlflow.log_metrics({"loss": loss, "val_acc": acc}, step=global_step)
+                    time.sleep(0.01)
+
+            report = {
+                "runId": state.runId,
+                "datasetId": state.datasetId,
+                "epochs": state.epochs,
+                "best": {"loss": loss, "val_acc": acc},
+                "finishedAt": datetime.utcnow().isoformat()+"Z"
+            }
+            uris = _upload_artifacts(state.runId, report)
+            state.artifactUris.update(uris)
+
+            if "report" in uris:
+                mlflow.log_params({"artifact_weights_uri": uris.get("weights",""),
+                                   "artifact_report_uri": uris.get("report","")})
+
+        state.status = "succeeded"
+        state.finishedAt = datetime.utcnow().isoformat()+"Z"
+        state.mlflowRunId = mlflow_run_id
+        log_event("training.completed", run_id=state.runId, dataset_id=state.datasetId, mlflow_run_id=mlflow_run_id)
+    except Exception as e:
+        state.status = "failed"
+        state.finishedAt = datetime.utcnow().isoformat()+"Z"
+        log_event("training.failed", run_id=state.runId, dataset_id=state.datasetId, error=str(e))

--- a/ml/requirements.txt
+++ b/ml/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.115.0
+uvicorn[standard]==0.30.6
+pydantic==2.8.2
+prometheus-client==0.20.0
+mlflow==2.15.1
+boto3==1.34.150
+python-json-logger==2.0.7

--- a/ml/tests/test_ml_service.py
+++ b/ml/tests/test_ml_service.py
@@ -1,0 +1,22 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+def test_health():
+    c = TestClient(app)
+    r = c.get("/health")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"
+
+def test_train_and_status_progress():
+    c = TestClient(app)
+    r1 = c.post("/train", json={"epochs": 2, "stepsPerEpoch": 5, "lr": 0.001})
+    assert r1.status_code == 200
+    run_id = r1.json()["runId"]
+    r2 = c.get(f"/runs/{run_id}")
+    assert r2.status_code == 200
+    assert r2.json()["status"] in ("running","succeeded")
+    for _ in range(50):
+        r3 = c.get(f"/runs/{run_id}")
+        if r3.json()["status"] == "succeeded":
+            break
+    assert r3.json()["status"] == "succeeded"


### PR DESCRIPTION
## Summary
- add FastAPI-based training service with health, training endpoints, Prometheus metrics, MLflow tracking, and artifact uploads
- provide Dockerfile and requirements for ML service
- include tests covering health check and training workflow

## Testing
- `pip install --quiet -r ml/requirements.txt` (fails: Could not find a version that satisfies the requirement fastapi==0.115.0)
- `pytest ml/tests/test_ml_service.py -q` (fails: ModuleNotFoundError: No module named 'fastapi')


------
https://chatgpt.com/codex/tasks/task_e_68b0f1286d64832b9f741952de23d71a