### PR TITLE
serve: FastAPI skeleton with /health, /models/load, /predict, /metrics

### DIFF
--- a/api/api-app/pom.xml
+++ b/api/api-app/pom.xml
@@ -88,6 +88,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>4.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
             <version>${flyway.version}</version>

--- a/api/api-app/src/main/java/com/chessapp/api/config/ServingClientConfig.java
+++ b/api/api-app/src/main/java/com/chessapp/api/config/ServingClientConfig.java
@@ -1,0 +1,43 @@
+package com.chessapp.api.config;
+
+import java.time.Duration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import reactor.netty.http.client.HttpClient;
+import reactor.util.retry.Retry;
+
+@Configuration
+public class ServingClientConfig {
+
+    @Bean
+    public WebClient servingWebClient(@Value("${chs.serve.baseUrl:http://serve:8001}") String baseUrl) {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
+                .responseTimeout(Duration.ofSeconds(5))
+                .doOnConnected(conn -> conn
+                        .addHandlerLast(new ReadTimeoutHandler(5))
+                        .addHandlerLast(new WriteTimeoutHandler(5)));
+
+        Retry retrySpec = Retry.backoff(3, Duration.ofMillis(200))
+                .filter(throwable -> throwable instanceof WebClientResponseException ex
+                        && (ex.getStatusCode().is5xxServerError()
+                            || ex.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS))
+                .jitter(0.5);
+
+        return WebClient.builder()
+                .baseUrl(baseUrl)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .filter((request, next) -> next.exchange(request).retryWhen(retrySpec))
+                .build();
+    }
+}

--- a/api/api-app/src/main/java/com/chessapp/api/serving/ServingClient.java
+++ b/api/api-app/src/main/java/com/chessapp/api/serving/ServingClient.java
@@ -1,0 +1,12 @@
+package com.chessapp.api.serving;
+
+import java.util.Map;
+
+import com.chessapp.api.serving.dto.ModelsLoadRequest;
+import com.chessapp.api.serving.dto.PredictRequest;
+import com.chessapp.api.serving.dto.PredictResponse;
+
+public interface ServingClient {
+    PredictResponse predict(PredictRequest request, String runId, String username);
+    Map<String, Object> modelsLoad(ModelsLoadRequest request, String runId, String username);
+}

--- a/api/api-app/src/main/java/com/chessapp/api/serving/ServingClientWeb.java
+++ b/api/api-app/src/main/java/com/chessapp/api/serving/ServingClientWeb.java
@@ -1,0 +1,45 @@
+package com.chessapp.api.serving;
+
+import java.util.Map;
+
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.chessapp.api.serving.dto.ModelsLoadRequest;
+import com.chessapp.api.serving.dto.PredictRequest;
+import com.chessapp.api.serving.dto.PredictResponse;
+
+@Component
+public class ServingClientWeb implements ServingClient {
+
+    private final WebClient web;
+
+    public ServingClientWeb(WebClient servingWebClient) {
+        this.web = servingWebClient;
+    }
+
+    @Override
+    public PredictResponse predict(PredictRequest request, String runId, String username) {
+        return web.post().uri("/predict")
+                .header("X-Run-Id", runId)
+                .header("X-Username", username)
+                .header("X-Component", "serve")
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(PredictResponse.class)
+                .block();
+    }
+
+    @Override
+    public Map<String, Object> modelsLoad(ModelsLoadRequest request, String runId, String username) {
+        return web.post().uri("/models/load")
+                .header("X-Run-Id", runId)
+                .header("X-Username", username)
+                .header("X-Component", "serve")
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                .block();
+    }
+}

--- a/api/api-app/src/main/java/com/chessapp/api/serving/ServingController.java
+++ b/api/api-app/src/main/java/com/chessapp/api/serving/ServingController.java
@@ -1,0 +1,103 @@
+package com.chessapp.api.serving;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.slf4j.MDC;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import com.chessapp.api.serving.dto.ModelsLoadRequest;
+import com.chessapp.api.serving.dto.PredictRequest;
+import com.chessapp.api.serving.dto.PredictResponse;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+@RestController
+@RequestMapping("/v1")
+public class ServingController {
+
+    private static final Logger log = LoggerFactory.getLogger(ServingController.class);
+
+    private final ServingClient client;
+    private final MeterRegistry registry;
+    private final String defaultUsername;
+
+    public ServingController(ServingClient client, MeterRegistry registry,
+                             @Value("${chs.default-username:M3NG00S3}") String defaultUsername) {
+        this.client = client;
+        this.registry = registry;
+        this.defaultUsername = defaultUsername;
+    }
+
+    @PostMapping("/predict")
+    public ResponseEntity<?> predict(@RequestBody PredictRequest body,
+                                     @RequestHeader(value = "X-Run-Id", required = false) String runId,
+                                     @RequestHeader(value = "X-Username", required = false) String username) {
+        String rid = runId != null ? runId : UUID.randomUUID().toString();
+        String user = username != null ? username : defaultUsername;
+        MDC.put("run_id", rid);
+        MDC.put("username", user);
+        MDC.put("component", "serve");
+        log.info("event=predict.requested");
+        Timer.Sample sample = Timer.start(registry);
+        try {
+            PredictResponse resp = client.predict(body, rid, user);
+            String modelId = resp.modelId() != null ? resp.modelId() : "unknown";
+            sample.stop(Timer.builder("chs_predict_latency_seconds")
+                    .tags("username", user, "model_id", modelId, "status", "ok")
+                    .register(registry));
+            Counter.builder("chs_predict_requests_total")
+                    .tags("username", user, "model_id", modelId, "status", "ok")
+                    .register(registry)
+                    .increment();
+            log.info("event=predict.completed");
+            return ResponseEntity.ok(resp);
+        } catch (WebClientResponseException ex) {
+            String modelId = "unknown";
+            sample.stop(Timer.builder("chs_predict_latency_seconds")
+                    .tags("username", user, "model_id", modelId, "status", "error")
+                    .register(registry));
+            Counter.builder("chs_predict_requests_total")
+                    .tags("username", user, "model_id", modelId, "status", "error")
+                    .register(registry)
+                    .increment();
+            log.warn("event=predict.failed");
+            HttpStatus status = ex.getStatusCode().is5xxServerError() ? HttpStatus.BAD_GATEWAY : HttpStatus.BAD_REQUEST;
+            return ResponseEntity.status(status).body(ex.getResponseBodyAsString());
+        } finally {
+            MDC.clear();
+        }
+    }
+
+    @PostMapping("/models/load")
+    public ResponseEntity<?> modelsLoad(@RequestBody ModelsLoadRequest body,
+                                        @RequestHeader(value = "X-Run-Id", required = false) String runId,
+                                        @RequestHeader(value = "X-Username", required = false) String username) {
+        String rid = runId != null ? runId : UUID.randomUUID().toString();
+        String user = username != null ? username : defaultUsername;
+        MDC.put("run_id", rid);
+        MDC.put("username", user);
+        MDC.put("component", "serve");
+        try {
+            Map<String, Object> resp = client.modelsLoad(body, rid, user);
+            return ResponseEntity.ok(resp);
+        } catch (WebClientResponseException ex) {
+            HttpStatus status = ex.getStatusCode().is5xxServerError() ? HttpStatus.BAD_GATEWAY : HttpStatus.BAD_REQUEST;
+            return ResponseEntity.status(status).body(ex.getResponseBodyAsString());
+        } finally {
+            MDC.clear();
+        }
+    }
+}

--- a/api/api-app/src/main/java/com/chessapp/api/serving/dto/ModelsLoadRequest.java
+++ b/api/api-app/src/main/java/com/chessapp/api/serving/dto/ModelsLoadRequest.java
@@ -1,0 +1,3 @@
+package com.chessapp.api.serving.dto;
+
+public record ModelsLoadRequest(String modelId, String artifactUri) {}

--- a/api/api-app/src/main/java/com/chessapp/api/serving/dto/PredictRequest.java
+++ b/api/api-app/src/main/java/com/chessapp/api/serving/dto/PredictRequest.java
@@ -1,0 +1,3 @@
+package com.chessapp.api.serving.dto;
+
+public record PredictRequest(String fen) {}

--- a/api/api-app/src/main/java/com/chessapp/api/serving/dto/PredictResponse.java
+++ b/api/api-app/src/main/java/com/chessapp/api/serving/dto/PredictResponse.java
@@ -1,0 +1,5 @@
+package com.chessapp.api.serving.dto;
+
+import java.util.List;
+
+public record PredictResponse(String move, List<String> legal, String modelId, String modelVersion) {}

--- a/api/api-app/src/main/resources/application-codex.yml
+++ b/api/api-app/src/main/resources/application-codex.yml
@@ -43,6 +43,8 @@ logging:
 
 chs:
   default-username: ${CHESS_USERNAME:M3NG00S3}
+  serve:
+    baseUrl: ${CHS_SERVE_BASEURL:http://serve:8001}
 
 chess:
   ingest:

--- a/api/api-app/src/main/resources/application.yml
+++ b/api/api-app/src/main/resources/application.yml
@@ -34,6 +34,8 @@ logging:
     root: INFO
     com.chessapp.api: INFO
     org.flywaydb: DEBUG
+    # WebClient logging (set env LOGGING_LEVEL_ORG_SPRINGFRAMEWORK_WEB_REACTIVE_FUNCTION_CLIENT=DEBUG to override)
+    org.springframework.web.reactive.function.client: INFO
   pattern:
     console: "{\"ts\":\"%d{yyyy-MM-dd'T'HH:mm:ss.SSSX}\",\"level\":\"%p\",\"logger\":\"%c{1}\",\"msg\":%m,\"run_id\":\"%X{run_id}\",\"component\":\"training\"}%n"
 chs:

--- a/api/api-app/src/main/resources/application.yml
+++ b/api/api-app/src/main/resources/application.yml
@@ -40,6 +40,8 @@ chs:
   default-username: ${CHESS_USERNAME:M3NG00S3}
   ml:
     base-url: ${ML_BASE_URL:http://ml:8000}
+  serve:
+    baseUrl: ${CHS_SERVE_BASEURL:http://serve:8001}
 chess:
   ingest:
     baseUrl: https://api.chess.com

--- a/api/api-app/src/test/java/com/chessapp/api/serving/ServingControllerIT.java
+++ b/api/api-app/src/test/java/com/chessapp/api/serving/ServingControllerIT.java
@@ -1,0 +1,101 @@
+package com.chessapp.api.serving;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import com.chessapp.api.serving.dto.ModelsLoadRequest;
+import com.chessapp.api.serving.dto.PredictRequest;
+import com.chessapp.api.serving.dto.PredictResponse;
+import com.chessapp.api.testutil.AbstractIntegrationTest;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = com.chessapp.api.codex.CodexApplication.class)
+class ServingControllerIT extends AbstractIntegrationTest {
+
+    static MockWebServer serve = new MockWebServer();
+
+    @DynamicPropertySource
+    static void serveProps(DynamicPropertyRegistry registry) {
+        registry.add("chs.serve.baseUrl", () -> serve.url("/").toString());
+    }
+
+    @BeforeAll
+    static void start() throws IOException {
+        serve.start();
+    }
+
+    @AfterAll
+    static void stop() throws IOException {
+        serve.shutdown();
+    }
+
+    @Autowired
+    TestRestTemplate rest;
+
+    @Autowired
+    MeterRegistry meterRegistry;
+
+    @Test
+    void predict_happy_path() throws InterruptedException {
+        serve.enqueue(new MockResponse()
+                .setBody("{\"move\":\"e2e4\",\"legal\":[\"e2e4\"],\"modelId\":\"dummy\",\"modelVersion\":\"0\"}")
+                .addHeader("Content-Type", "application/json"));
+
+        ResponseEntity<PredictResponse> resp = rest.postForEntity("/v1/predict",
+                new PredictRequest("some"), PredictResponse.class);
+
+        assertThat(resp.getStatusCode().value()).isEqualTo(200);
+        assertThat(resp.getBody()).isNotNull();
+        assertThat(resp.getBody().move()).isEqualTo("e2e4");
+
+        RecordedRequest req = serve.takeRequest();
+        assertThat(req.getHeader("X-Run-Id")).isNotBlank();
+        assertThat(req.getHeader("X-Username")).isEqualTo("M3NG00S3");
+        assertThat(req.getHeader("X-Component")).isEqualTo("serve");
+
+        Counter c = meterRegistry.find("chs_predict_requests_total")
+                .tags("username", "M3NG00S3", "model_id", "dummy", "status", "ok")
+                .counter();
+        assertThat(c).isNotNull();
+        assertThat(c.count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void predict_error_path() {
+        serve.enqueue(new MockResponse().setResponseCode(400));
+        ResponseEntity<String> resp = rest.postForEntity("/v1/predict",
+                new PredictRequest("bad"), String.class);
+        assertThat(resp.getStatusCode().value()).isEqualTo(400);
+    }
+
+    @Test
+    void models_load_proxy_ok() throws InterruptedException {
+        serve.enqueue(new MockResponse()
+                .setBody("{\"modelId\":\"dummy\",\"modelVersion\":\"0\"}")
+                .addHeader("Content-Type", "application/json"));
+
+        ResponseEntity<String> resp = rest.postForEntity("/v1/models/load",
+                new ModelsLoadRequest("dummy", null), String.class);
+        assertThat(resp.getStatusCode().value()).isEqualTo(200);
+
+        RecordedRequest req = serve.takeRequest();
+        assertThat(req.getPath()).isEqualTo("/models/load");
+    }
+}

--- a/api/api-app/target/classes/application.yml
+++ b/api/api-app/target/classes/application.yml
@@ -34,8 +34,16 @@ logging:
     root: INFO
     com.chessapp.api: INFO
     org.flywaydb: DEBUG
+    # WebClient logging (set env LOGGING_LEVEL_ORG_SPRINGFRAMEWORK_WEB_REACTIVE_FUNCTION_CLIENT=DEBUG to override)
+    org.springframework.web.reactive.function.client: INFO
+  pattern:
+    console: "{\"ts\":\"%d{yyyy-MM-dd'T'HH:mm:ss.SSSX}\",\"level\":\"%p\",\"logger\":\"%c{1}\",\"msg\":%m,\"run_id\":\"%X{run_id}\",\"component\":\"training\"}%n"
 chs:
   default-username: ${CHESS_USERNAME:M3NG00S3}
+  ml:
+    base-url: ${ML_BASE_URL:http://ml:8000}
+  serve:
+    baseUrl: ${CHS_SERVE_BASEURL:http://serve:8001}
 chess:
   ingest:
     baseUrl: https://api.chess.com

--- a/api/api-common/src/main/java/com/chessapp/api/common/GlobalExceptionHandler.java
+++ b/api/api-common/src/main/java/com/chessapp/api/common/GlobalExceptionHandler.java
@@ -3,6 +3,8 @@ package com.chessapp.api.common;
 import java.time.Instant;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -14,6 +16,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, Object>> handleValidation(MethodArgumentNotValidException ex) {
@@ -69,6 +73,7 @@ public class GlobalExceptionHandler {
         if (ex instanceof ResponseStatusException rse) {
             return handleResponseStatus(rse);
         }
+        log.error("Unhandled exception", ex);
         return ResponseEntity.internalServerError().body(Map.of(
                 "timestamp", Instant.now().toString(),
                 "status", HttpStatus.INTERNAL_SERVER_ERROR.value(),

--- a/docs/SERVE.md
+++ b/docs/SERVE.md
@@ -1,0 +1,30 @@
+# Serving Service
+
+The `serve` component exposes a FastAPI service on port **8001** for model loading, prediction and metrics.
+
+## Example usage
+
+```bash
+# health
+curl -s localhost:8001/health
+# dummy model
+curl -s -XPOST localhost:8001/models/load -H 'Content-Type: application/json' -d '{}'
+# predict (direct)
+curl -s -XPOST localhost:8001/predict -H 'Content-Type: application/json' -d '{"fen":"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"}'
+# predict via API proxy
+curl -s -XPOST localhost:8080/v1/predict -H 'Content-Type: application/json' -H 'X-Username: M3NG00S3' -d '{"fen":"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"}'
+# metrics
+curl -s localhost:8001/metrics | grep chs_predict_
+```
+
+## Observability
+
+Metrics are exposed via `/metrics` and prefixed with `chs_predict_`.
+
+Logs can be queried in Loki, e.g.:
+
+```logql
+{container="chs_serve"} |= "predict."
+```
+
+Each log line carries fields such as `event`, `run_id`, `username`, `model_id`, and `component="serve"`.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -178,7 +178,7 @@ services:
       loki:
         condition: service_healthy
     networks: [chs_net]
-  ml:
+    ml:
     build:
       context: ../
       dockerfile: ml/Dockerfile
@@ -200,6 +200,28 @@ services:
       retries: 10
     ports:
       - "8000:8000"
+      networks: [ chs_net ]
+      restart: unless-stopped
+
+  serve:
+    build: ../serve
+    container_name: chs_serve
+    environment:
+      ML_S3_ENDPOINT: http://minio:9000
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
+      AWS_REGION: us-east-1
+      DEFAULT_USERNAME: M3NG00S3
+    ports:
+      - "8001:8001"
+    depends_on:
+      - minio
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8001/health | grep -q 'ok'"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
     networks: [ chs_net ]
     restart: unless-stopped
   api:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -178,7 +178,8 @@ services:
       loki:
         condition: service_healthy
     networks: [chs_net]
-    ml:
+
+  ml:
     build:
       context: ../
       dockerfile: ml/Dockerfile
@@ -200,8 +201,8 @@ services:
       retries: 10
     ports:
       - "8000:8000"
-      networks: [ chs_net ]
-      restart: unless-stopped
+    networks: [ chs_net ]
+    restart: unless-stopped
 
   serve:
     build: ../serve
@@ -217,7 +218,7 @@ services:
     depends_on:
       - minio
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:8001/health | grep -q 'ok'"]
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8001/health | grep -q '\"status\":\"ok\"'"]
       interval: 10s
       timeout: 3s
       retries: 10

--- a/infra/grafana/provisioning/dashboards/json/chessapp-overview.json
+++ b/infra/grafana/provisioning/dashboards/json/chessapp-overview.json
@@ -50,7 +50,7 @@
     {
       "type": "logs",
       "title": "API Logs (Loki)",
-      "gridPos": { "x": 0, "y": 29, "w": 24, "h": 12 },
+      "gridPos": { "x": 0, "y": 37, "w": 24, "h": 12 },
       "options": {
         "showLabels": true,
         "showTime": true,
@@ -87,6 +87,49 @@
       "gridPos": { "x": 0, "y": 24, "w": 6, "h": 5 },
       "targets": [
         { "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "sum(chs_training_runs_total)" }
+      ]
+    },
+    {
+      "uid": "serveReq",
+      "type": "timeseries",
+      "title": "Serve Requests/min (by status)",
+      "gridPos": { "x": 0, "y": 29, "w": 8, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "ops" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (status) (rate(chs_predict_requests_total[1m]))",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "uid": "serveLat",
+      "type": "heatmap",
+      "title": "Predict Latency",
+      "gridPos": { "x": 8, "y": 29, "w": 8, "h": 8 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(chs_predict_latency_seconds_bucket[1m])) by (le)",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "uid": "serveIll",
+      "type": "stat",
+      "title": "Illegal Requests (sum)",
+      "gridPos": { "x": 16, "y": 29, "w": 8, "h": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(chs_predict_illegal_requests_total)",
+          "refId": "A"
+        }
       ]
     }
   ]

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -19,3 +19,6 @@ scrape_configs:
     metrics_path: /metrics
     static_configs:
       - targets: ['ml:8000']
+  - job_name: serve
+    static_configs:
+      - targets: ['serve:8001']

--- a/serve/Dockerfile
+++ b/serve/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/serve/Dockerfile
+++ b/serve/Dockerfile
@@ -2,6 +2,10 @@ FROM python:3.11-slim
 
 WORKDIR /app
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+# Install minimal debugging/health tools and keep image slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl wget grep \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir -r requirements.txt
 COPY . .
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/serve/app/main.py
+++ b/serve/app/main.py
@@ -1,0 +1,180 @@
+import json
+import logging
+import os
+import time
+from typing import List, Optional
+
+import chess
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+from prometheus_client import Counter, Histogram, CONTENT_TYPE_LATEST, generate_latest
+
+# --- Config ---
+ML_S3_ENDPOINT = os.getenv("ML_S3_ENDPOINT", "http://minio:9000")
+AWS_REGION = os.getenv("AWS_REGION", "us-east-1")
+AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID")
+AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY")
+DEFAULT_USERNAME = os.getenv("DEFAULT_USERNAME", "M3NG00S3")
+
+# --- Logging ---
+logger = logging.getLogger("serve")
+logger.setLevel(logging.INFO)
+handler = logging.StreamHandler()
+try:
+    from python_json_logger import jsonlogger
+    handler.setFormatter(jsonlogger.JsonFormatter())
+except Exception:
+    handler.setFormatter(logging.Formatter("%(message)s"))
+logger.handlers = [handler]
+
+
+def log_event(event: str, **extra):
+    payload = {"event": event, "component": "serve"}
+    payload.update({k: v for k, v in extra.items() if v is not None})
+    logger.info(json.dumps(payload))
+
+
+# --- Metrics ---
+PREDICT_REQUESTS = Counter(
+    "chs_predict_requests_total",
+    "Total predict requests",
+    ["username", "model_id", "status"],
+)
+PREDICT_LATENCY = Histogram(
+    "chs_predict_latency_seconds", "Prediction latency seconds"
+)
+ILLEGAL_REQUESTS = Counter(
+    "chs_predict_illegal_requests_total", "Illegal predict requests"
+)
+
+
+# --- Models ---
+class ModelState(BaseModel):
+    modelId: str
+    modelVersion: str
+    artifactUri: Optional[str] = None
+
+
+class LoadModelRequest(BaseModel):
+    modelId: Optional[str] = None
+    artifactUri: Optional[str] = None
+
+
+class PredictRequest(BaseModel):
+    fen: str
+
+
+class PredictResponse(BaseModel):
+    move: str
+    legal: List[str]
+    modelId: str
+    modelVersion: str
+
+
+current_model = ModelState(modelId="dummy", modelVersion="0")
+
+app = FastAPI(title="ChessApp Serve", version="0.1")
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+
+@app.get("/metrics")
+def metrics():
+    data = generate_latest()
+    return Response(data, media_type=CONTENT_TYPE_LATEST)
+
+
+@app.post("/models/load")
+def models_load(req: LoadModelRequest):
+    global current_model
+    if req.artifactUri and req.artifactUri.startswith("s3://"):
+        try:
+            import boto3
+
+            bucket, key = req.artifactUri[5:].split("/", 1)
+            s3 = boto3.client(
+                "s3",
+                endpoint_url=ML_S3_ENDPOINT,
+                aws_access_key_id=AWS_ACCESS_KEY_ID,
+                aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+                region_name=AWS_REGION,
+            )
+            s3.download_file(bucket, key, "/tmp/model.weights")
+            current_model = ModelState(
+                modelId=req.modelId or "model", modelVersion="1", artifactUri=req.artifactUri
+            )
+        except Exception:
+            current_model = ModelState(modelId="dummy", modelVersion="0")
+    else:
+        current_model = ModelState(modelId="dummy", modelVersion="0")
+    return current_model.dict()
+
+
+@app.post("/predict", response_model=PredictResponse)
+def predict(req: PredictRequest, request: Request, response: Response):
+    start = time.perf_counter()
+    run_id = request.headers.get("X-Run-Id")
+    username = request.headers.get("X-Username", DEFAULT_USERNAME)
+    status = "ok"
+    try:
+        log_event("predict.request", run_id=run_id, username=username, model_id=current_model.modelId)
+        try:
+            board = chess.Board(fen=req.fen)
+        except Exception:
+            status = "error"
+            ILLEGAL_REQUESTS.inc()
+            PREDICT_REQUESTS.labels(username=username, model_id=current_model.modelId, status=status).inc()
+            log_event(
+                "predict.failed",
+                run_id=run_id,
+                username=username,
+                model_id=current_model.modelId,
+                error="invalid_fen",
+            )
+            return JSONResponse(
+                status_code=400,
+                content={"error": "invalid_fen"},
+                headers={"X-Component": "serve"},
+            )
+
+        legal_moves = [m.uci() for m in board.legal_moves]
+        if not legal_moves:
+            status = "error"
+            ILLEGAL_REQUESTS.inc()
+            PREDICT_REQUESTS.labels(username=username, model_id=current_model.modelId, status=status).inc()
+            log_event(
+                "predict.failed",
+                run_id=run_id,
+                username=username,
+                model_id=current_model.modelId,
+                error="invalid_fen",
+            )
+            return JSONResponse(
+                status_code=400,
+                content={"error": "invalid_fen"},
+                headers={"X-Component": "serve"},
+            )
+
+        move = legal_moves[0]
+        response.headers["X-Component"] = "serve"
+        PREDICT_REQUESTS.labels(username=username, model_id=current_model.modelId, status=status).inc()
+        log_event(
+            "predict.completed",
+            run_id=run_id,
+            username=username,
+            model_id=current_model.modelId,
+            move=move,
+        )
+        return {
+            "move": move,
+            "legal": legal_moves,
+            "modelId": current_model.modelId,
+            "modelVersion": current_model.modelVersion,
+        }
+    finally:
+        elapsed = time.perf_counter() - start
+        PREDICT_LATENCY.observe(elapsed)

--- a/serve/pyproject.toml
+++ b/serve/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/serve/requirements.txt
+++ b/serve/requirements.txt
@@ -1,0 +1,10 @@
+fastapi
+uvicorn[standard]
+python-chess
+prometheus_client
+boto3
+pydantic
+python-json-logger
+httpx
+pytest
+pytest-asyncio

--- a/serve/tests/test_health.py
+++ b/serve/tests/test_health.py
@@ -1,0 +1,12 @@
+import pytest
+from httpx import AsyncClient
+
+from serve.app.main import app
+
+
+@pytest.mark.asyncio
+async def test_health():
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        resp = await ac.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}

--- a/serve/tests/test_models_load.py
+++ b/serve/tests/test_models_load.py
@@ -1,0 +1,34 @@
+import os
+import pytest
+from httpx import AsyncClient
+
+from serve.app.main import app
+
+
+@pytest.mark.asyncio
+async def test_models_load_dummy():
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        resp = await ac.post("/models/load", json={})
+    assert resp.status_code == 200
+    assert resp.json()["modelId"] == "dummy"
+
+
+@pytest.mark.asyncio
+async def test_models_load_artifact_uri_tolerance():
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        resp = await ac.post(
+            "/models/load", json={"artifactUri": "s3://bucket/key", "modelId": "foo"}
+        )
+    assert resp.status_code == 200
+
+
+@pytest.mark.skipif(not os.getenv("RUN_MINIO_TESTS"), reason="RUN_MINIO_TESTS not set")
+@pytest.mark.asyncio
+async def test_models_load_with_minio():
+    uri = os.getenv("MINIO_MODEL_URI")
+    if not uri:
+        pytest.skip("MINIO_MODEL_URI not set")
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        resp = await ac.post("/models/load", json={"artifactUri": uri, "modelId": "x"})
+    assert resp.status_code == 200
+    assert resp.json()["modelId"] != "dummy"

--- a/serve/tests/test_predict.py
+++ b/serve/tests/test_predict.py
@@ -1,0 +1,25 @@
+import pytest
+from httpx import AsyncClient
+
+from serve.app.main import app
+
+VALID_FEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+INVALID_FEN = "invalid fen"
+
+
+@pytest.mark.asyncio
+async def test_predict_valid_fen():
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        resp = await ac.post("/predict", json={"fen": VALID_FEN})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["move"] in data["legal"]
+    assert data["modelId"] == "dummy"
+
+
+@pytest.mark.asyncio
+async def test_predict_invalid_fen():
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        resp = await ac.post("/predict", json={"fen": INVALID_FEN})
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "invalid_fen"


### PR DESCRIPTION
## Summary
- add FastAPI service under `serve/` with health, model loading, prediction, and metrics endpoints
- include Dockerfile and requirements for serving component
- provide unit tests for health, model load, and prediction behavior

## Testing
- `pip install -r serve/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest serve/tests/test_health.py serve/tests/test_models_load.py serve/tests/test_predict.py` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68b16566a6c8832ba2238c6e09096a3a