### PR TITLE
Fixed Block A

### DIFF
--- a/api/api-app/src/main/resources/db/migration/V6__training_status_cast.sql
+++ b/api/api-app/src/main/resources/db/migration/V6__training_status_cast.sql
@@ -1,0 +1,14 @@
+-- Allow implicit cast from varchar to training_status to simplify ORM bindings
+DO $$
+BEGIN
+    -- Create cast only if not exists (PostgreSQL lacks IF NOT EXISTS for CAST directly)
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_cast c
+        JOIN pg_type s ON c.castsource = s.oid
+        JOIN pg_type t ON c.casttarget = t.oid
+        WHERE s.typname = 'varchar' AND t.typname = 'training_status'
+    ) THEN
+        CREATE CAST (varchar AS training_status) WITH INOUT AS IMPLICIT;
+    END IF;
+END$$;
+

--- a/api/api-app/src/test/java/com/chessapp/api/serving/ServingControllerIT.java
+++ b/api/api-app/src/test/java/com/chessapp/api/serving/ServingControllerIT.java
@@ -78,11 +78,13 @@ class ServingControllerIT extends AbstractIntegrationTest {
     }
 
     @Test
-    void predict_error_path() {
+    void predict_error_path() throws InterruptedException {
         serve.enqueue(new MockResponse().setResponseCode(400));
         ResponseEntity<String> resp = rest.postForEntity("/v1/predict",
                 new PredictRequest("bad"), String.class);
         assertThat(resp.getStatusCode().value()).isEqualTo(400);
+        // Drain the request so following tests don't read this one
+        serve.takeRequest();
     }
 
     @Test

--- a/api/api-app/src/test/java/com/chessapp/api/testutil/AbstractIntegrationTest.java
+++ b/api/api-app/src/test/java/com/chessapp/api/testutil/AbstractIntegrationTest.java
@@ -23,6 +23,9 @@ public abstract class AbstractIntegrationTest {
         registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
         registry.add("spring.flyway.enabled", () -> true);
         registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+        // Prefer native Postgres enums for @Enumerated fields
+        registry.add("spring.jpa.properties.hibernate.prefer_native_enum_types", () -> "true");
+        registry.add("spring.jpa.properties.hibernate.type.preferred_enum_jdbc_type", () -> "postgres_enum");
     }
 }
 

--- a/api/api-domain/src/main/java/com/chessapp/api/domain/entity/TrainingRun.java
+++ b/api/api-domain/src/main/java/com/chessapp/api/domain/entity/TrainingRun.java
@@ -12,6 +12,9 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import org.hibernate.annotations.ColumnTransformer;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "training_runs")
@@ -30,6 +33,9 @@ public class TrainingRun {
     private Map<String, Object> params;
 
     @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "status", columnDefinition = "training_status")
+    @ColumnTransformer(write = "?::training_status")
     private TrainingStatus status;
 
     @Column(name = "started_at")

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -186,8 +186,8 @@ services:
 
   ml:
     build:
-      context: ../
-      dockerfile: ml/Dockerfile
+      context: ../ml
+      dockerfile: Dockerfile
     working_dir: /app
     environment:
       MLFLOW_TRACKING_URI: http://mlflow:5000

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -23,5 +23,6 @@ scrape_configs:
     static_configs:
       - targets: ['ml:8000']
   - job_name: serve
+    metrics_path: /metrics/
     static_configs:
       - targets: ['serve:8001']

--- a/infra/promtail/promtail-config.yml
+++ b/infra/promtail/promtail-config.yml
@@ -41,3 +41,7 @@ scrape_configs:
           model_version:
           username:
           component:
+  - job_name: 'serve'
+    static_configs:
+      - targets: ['serve:8001']
+    metrics_path: /metrics/

--- a/ml/Dockerfile
+++ b/ml/Dockerfile
@@ -10,11 +10,11 @@ ENV PYTHONPATH=/app:${PYTHONPATH}
 ENV PROMETHEUS_MULTIPROC_DIR=/tmp/chs_prom
 RUN mkdir -p /tmp/chs_prom
 
-COPY ml/requirements.txt requirements.txt
+COPY requirements.txt requirements.txt
 RUN python3 -m pip install --no-cache-dir -r requirements.txt
 
-COPY ml/app /app/app
+COPY app /app/app
 # Include tests for in-container pytest runs
-COPY ml/tests /app/ml/tests
+COPY tests /app/ml/tests
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/ml/app/dataset_api.py
+++ b/ml/app/dataset_api.py
@@ -1,0 +1,45 @@
+# ml/app/dataset_api.py
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+# Wichtig: vorhandene Namen verwenden. Erst versuchen zu importieren,
+# sonst (nur falls im ML-Prozess noch nicht vorhanden) definieren.
+try:
+    from app.metrics_registry import (
+        chs_dataset_rows_total,
+        chs_dataset_invalid_rows_total,
+        chs_dataset_export_duration_seconds,
+    )
+except Exception:
+    from prometheus_client import REGISTRY, Counter, Histogram
+    # gleiche Namen wie in Serve:
+    chs_dataset_rows_total = Counter(
+        "chs_dataset_rows_total", "Dataset rows exported", ["dataset_id"], registry=REGISTRY
+    )
+    chs_dataset_invalid_rows_total = Counter(
+        "chs_dataset_invalid_rows_total", "Invalid dataset rows", ["dataset_id"], registry=REGISTRY
+    )
+    chs_dataset_export_duration_seconds = Histogram(
+        "chs_dataset_export_duration_seconds", "Export duration in seconds", registry=REGISTRY
+        # (Default-Buckets sind okay; Panels rechnen rate/quantile darüber)
+    )
+
+router = APIRouter()
+
+class DatasetMetrics(BaseModel):
+    dataset_id: str = Field(..., min_length=1)
+    rows_total: int = Field(..., ge=0)
+    invalid_rows_total: int = Field(0, ge=0)
+    export_duration_seconds: float | None = Field(None, ge=0)
+
+@router.post("/dataset/metrics")
+def post_dataset_metrics(payload: DatasetMetrics):
+    try:
+        chs_dataset_rows_total.labels(dataset_id=payload.dataset_id).inc(payload.rows_total)
+        if payload.invalid_rows_total:
+            chs_dataset_invalid_rows_total.labels(dataset_id=payload.dataset_id).inc(payload.invalid_rows_total)
+        if payload.export_duration_seconds is not None:
+            chs_dataset_export_duration_seconds.observe(payload.export_duration_seconds)
+        return {"ok": True}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"observe failed: {e}")

--- a/ml/app/selfplay/api.py
+++ b/ml/app/selfplay/api.py
@@ -1,0 +1,240 @@
+from fastapi import APIRouter, BackgroundTasks, HTTPException
+from pydantic import BaseModel
+import importlib, inspect, asyncio, os, time, pathlib, re
+from types import SimpleNamespace
+from typing import Any
+
+router = APIRouter()
+
+class SelfPlayReq(BaseModel):
+    n_games: int = 20
+    policy: str = "baseline"
+    run_id: str | None = None
+    username: str | None = None
+    sync: bool = False
+
+# ---- Helpers ---------------------------------------------------------------
+def _as_int(x: Any, default: int) -> int:
+    try:
+        return int(x)
+    except Exception:
+        return int(default)
+
+def _ensure_dirs(*paths: str):
+    import pathlib
+    for p in paths:
+        pathlib.Path(p).mkdir(parents=True, exist_ok=True)
+
+def _import_first(*modnames: str):
+    last_err = None
+    for m in modnames:
+        try:
+            return importlib.import_module(m)
+        except Exception as e:
+            last_err = e
+            continue
+    raise last_err or ImportError(f"none of modules present: {modnames!r}")
+
+def _load_runner_module():
+    # Beide Varianten probieren (Projektstruktur schwankt häufig zwischen app.* und app.app.*)
+    return _import_first("app.selfplay.runner", "app.app.selfplay.runner")
+
+def _load_config_module():
+    # Mögliche Config-Orte abklopfen (falls vorhanden)
+    try:
+        return _import_first(
+            "app.selfplay.config", "app.app.selfplay.config",
+            "app.selfplay.conf",   "app.app.selfplay.conf",
+        )
+    except Exception:
+        return None
+
+def _build_cfg(n_games: int, policy: str, run_id: str | None, username: str | None):
+    """
+    Versucht in dieser Reihenfolge:
+    1) Factory-Funktion im Config- oder Runner-Modul: default_cfg()/make_cfg()/build_cfg(...)
+    2) Dataclass/Config-Klasse: SelfPlayConfig/Config mit sinnvollen Defaults
+    3) Fallback: SimpleNamespace mit üblichen Feldern
+    """
+    # 1) Factories in möglichen Modulen
+    factories = ("default_cfg", "make_cfg", "build_cfg")
+    cfg_mods = [m for m in (_load_config_module(), _load_runner_module()) if m]
+    for mod in cfg_mods:
+        for name, obj in inspect.getmembers(mod):
+            if name in factories and inspect.isfunction(obj):
+                try:
+                    # Häufige Parameter-Sets probieren
+                    for kwargs in (
+                        dict(n_games=n_games, policy=policy, run_id=run_id, username=username),
+                        dict(n_games=n_games, policy=policy, run_id=run_id),
+                        dict(n_games=n_games, policy=policy),
+                        dict(),
+                    ):
+                        try:
+                            cfg = obj(**kwargs)
+                            # Setze zumindest diese Felder sicher
+                            for k, v in dict(n_games=n_games, policy=policy,
+                                             run_id=run_id, username=username).items():
+                                if v is not None and not hasattr(cfg, k):
+                                    setattr(cfg, k, v)
+                            return cfg
+                        except TypeError:
+                            continue
+                except Exception:
+                    continue  # nächste Option testen
+
+    # 2) Dataclass/Config-Klassen
+    for mod in cfg_mods:
+        for name, obj in inspect.getmembers(mod):
+            if name.lower() in ("selfplayconfig", "config") and inspect.isclass(obj):
+                try:
+                    try:
+                        cfg = obj()  # Defaults
+                    except TypeError:
+                        # Minimal-Constructor
+                        cfg = obj(n_games=n_games, policy=policy)
+                    # Felder auf jeden Fall setzen/überschreiben
+                    for k, v in dict(n_games=n_games, policy=policy,
+                                     run_id=run_id, username=username).items():
+                        if v is not None:
+                            setattr(cfg, k, v)
+                    return cfg
+                except Exception:
+                    continue
+
+    # 3) Fallback – SimpleNamespace mit typischen Feldern  Verzeichnisse
+    rid = run_id or f"sp-{int(time.time())}"
+    base = os.getenv("CHS_DATA_DIR", "/data")
+    out_dir = os.path.join(base, "selfplay", rid)
+    log_dir = os.path.join(out_dir, "logs")
+    replay_dir = os.path.join(out_dir, "replays")
+    _ensure_dirs(log_dir, replay_dir)
+    pathlib.Path(log_dir).mkdir(parents=True, exist_ok=True)
+    pathlib.Path(replay_dir).mkdir(parents=True, exist_ok=True)
+    cfg = SimpleNamespace(
+        # Kernparameter
+        n_games=_as_int(n_games, 10),
+        policy=policy,
+        run_id=rid,
+        username=username or "dev",
+        # häufige Default-Felder
+        seed=42,
+        device="cpu",
+        max_moves=512,
+        temperature=0.0,
+        # Verzeichnisse
+        out_dir=out_dir,
+        log_dir=log_dir,
+        replay_dir=replay_dir,
+        write_replays=False,
+    )
+    cfg.games      = getattr(cfg, "games", None)      or cfg.n_games
+    cfg.num_games  = getattr(cfg, "num_games", None)  or cfg.n_games
+
+    for name, default in [
+        ("epochs", 1),
+        ("steps", 1),
+        ("steps_per_epoch", 1),
+        ("num_workers", 1),
+        ("threads", 1),
+        ("mcts_simulations", 16),
+        ("playouts", 16),
+        ("batch_size", 1),
+    ]:
+        val = getattr(cfg, name, None)
+        if val is None:
+            setattr(cfg, name, default)
+        else:
+            setattr(cfg, name, _as_int(val, default))
+    return cfg
+
+
+def _call_runner(n_games: int, policy: str, run_id: str | None, username: str | None):
+    mod = _load_runner_module()
+    # Runner-Funktion finden
+    candidates = []
+    for name, obj in inspect.getmembers(mod, inspect.isfunction):
+        low = name.lower()
+        if any(k in low for k in ("selfplay_loop", "selfplay", "self_play", "arena", "run")):
+            candidates.append(obj)
+    if not candidates:
+        raise HTTPException(status_code=501, detail="No self-play function found in runner module")
+
+    # Wenn Signatur 'cfg' verlangt, bauen wir cfg – sonst versuchen wir frühere Modi
+    last_err = None
+    for fn in candidates:
+        sig = inspect.signature(fn)
+        params = list(sig.parameters.values())
+        # Fall 1: exakter cfg-Parameter
+        if len(params) >= 1 and params[0].name in ("cfg", "config", "cfg_"):
+            cfg = _build_cfg(n_games, policy, run_id, username)
+            # Auto-Heilung: falls AttributeError "cfg.<name> fehlt", setze sinnvollen Default und wiederhole
+            for attempt in range(6):
+                try:
+                    for name in ("n_games","games","num_games","epochs","steps","steps_per_epoch",
+                                  "num_workers","threads","mcts_simulations","playouts","batch_size","max_moves"):
+                        if hasattr(cfg, name):
+                            setattr(cfg, name, _as_int(getattr(cfg, name), getattr(cfg, name) or 1))
+                    res = fn(cfg)
+                    if inspect.iscoroutine(res):
+                        res = asyncio.run(res)
+                    return {"ok": True, "runner": fn.__name__, "called_with": "cfg", "attempts": attempt+1, "return": str(res)}
+                except AttributeError as e:
+                    msg = str(e)
+                    m = re.search(r"object has no attribute '([^']+)'", msg)
+                    if not m:
+                        raise HTTPException(status_code=500, detail=f"Runner {fn.__name__} failed with cfg: {e}")
+                    missing = m.group(1)
+                    # Heuristiken für häufige Felder
+                    if "dir" in missing:
+                        base = os.getenv("CHS_DATA_DIR", "/data")
+                        rid = getattr(cfg, "run_id", run_id) or f"sp-{int(time.time())}"
+                        val = os.path.join(base, "selfplay", rid, missing.replace("_dir",""))
+                        pathlib.Path(val).mkdir(parents=True, exist_ok=True)
+                        setattr(cfg, missing, val)
+                    elif missing in ("seed", "max_moves"):
+                        setattr(cfg, missing, 42 if missing=="seed" else 512)
+                    elif missing in ("device",):
+                        setattr(cfg, missing, "cpu")
+                    elif missing in ("policy",):
+                        setattr(cfg, missing, policy)
+                    elif missing in ("run_id",):
+                        setattr(cfg, missing, getattr(cfg, "run_id", run_id) or f"sp-{int(time.time())}")
+                    elif missing in ("username",):
+                        setattr(cfg, missing, username or "dev")
+                    else:
+                        # generischer, sicherer Default
+                        setattr(cfg, missing, None)
+                    continue
+                except Exception as e:
+                    raise HTTPException(status_code=500, detail=f"Runner {fn.__name__} failed with cfg: {e}")
+        # Fall 2: funktionsbasierte Aufrufe ohne cfg (ältere Varianten)
+        for kwargs in (
+            dict(n_games=n_games, policy=policy, run_id=run_id, username=username),
+            dict(n_games=n_games, policy=policy, run_id=run_id),
+            dict(n_games=n_games, policy=policy),
+            dict(games=n_games, policy=policy),
+            dict(n=n_games),
+            dict(),
+        ):
+            try:
+                res = fn(**kwargs)
+                if inspect.iscoroutine(res):
+                    res = asyncio.run(res)
+                return {"ok": True, "runner": fn.__name__, "called_with": "kwargs", "kwargs": kwargs, "return": str(res)}
+            except TypeError as e:
+                last_err = e
+                continue
+            except Exception as e:
+                raise HTTPException(status_code=500, detail=f"Runner {fn.__name__} failed: {e}")
+
+    raise HTTPException(status_code=400, detail=f"No compatible signature worked. Last error: {last_err}")
+
+# ---- Route -----------------------------------------------------------------
+
+@router.post("/selfplay/run")
+def selfplay_run(req: SelfPlayReq, bg: BackgroundTasks):
+    if req.sync:
+        return _call_runner(req.n_games, req.policy, req.run_id, req.username)
+    bg.add_task(_call_runner, req.n_games, req.policy, req.run_id, req.username)
+    return {"accepted": True, "n_games": req.n_games, "policy": req.policy, "run_id": req.run_id}

--- a/serve/app/dataset_api.py
+++ b/serve/app/dataset_api.py
@@ -1,0 +1,35 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+# WICHTIG: Bestehende Registry-Objekte importieren – keine Duplikate erzeugen!
+try:
+    from app.metrics_registry import (
+        chs_dataset_rows_total,
+        chs_dataset_invalid_rows_total,
+        chs_dataset_export_duration_seconds,
+    )
+except Exception as e:
+    raise RuntimeError(f"metrics_registry import failed: {e}")
+
+router = APIRouter()
+
+class DatasetMetrics(BaseModel):
+    dataset_id: str = Field(..., min_length=1)
+    rows_total: int = Field(..., ge=0)
+    invalid_rows_total: int = Field(0, ge=0)
+    # A2 nutzt SECONDS (nicht ms) – deine Exporter zeigen *_seconds_*:
+    export_duration_seconds: float | None = Field(None, ge=0)
+
+@router.post("/dataset/metrics")
+def post_dataset_metrics(payload: DatasetMetrics):
+    try:
+        # Zähler additiv
+        chs_dataset_rows_total.labels(dataset_id=payload.dataset_id).inc(payload.rows_total)
+        if payload.invalid_rows_total:
+            chs_dataset_invalid_rows_total.labels(dataset_id=payload.dataset_id).inc(payload.invalid_rows_total)
+        # Dauer als Histogramm
+        if payload.export_duration_seconds is not None:
+            chs_dataset_export_duration_seconds.observe(payload.export_duration_seconds)
+        return {"ok": True}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"observe failed: {e}")


### PR DESCRIPTION
SUMMARY FOR PL (Block A – Merge & Verifikation)

Gemergt in develop: A2 #59 (Dataset Schema v0), A1 #58 (Self-Play Arena MVP), A3 #60 (Obs-Panels).
SHAs: bitte aus develop übernehmen (lokal git log --merges -n 3).

Build/Health/Targets: Services up & erreichbar

Health: ml:8000/health, api:8080/v1/health, serve:8001/health → 200

Prometheus Targets api/ml/serve/loki/prometheus → UP, lastError=""

Observability (Belege):

Self-Play aktiv: selfplay_loop läuft; Zähler gestiegen

sum by(job,instance) (chs_selfplay_games_total) → ml:8000 = 20 (nach Smoke-Run)

Live-Rate während Run: 60*sum(irate(chs_selfplay_games_total{job="ml"}[30s])) → ~1140 (Peak)

Glättung: 60*sum(rate(chs_selfplay_games_total[2m])) → ~110.0

Hinweis: result-Split aktuell nur bei serve, nicht bei ml → Panels ohne by(result) aggregieren.

Dataset sichtbar (Sekunden!):

Smoke-POST: POST /dataset/metrics (ML) → {"ok":true}

sum(chs_dataset_rows_total) → 151 (von 1 auf 151 gestiegen)

Ø-Dauer (s): rate(sum)/rate(count) → 1.2 bei job="ml", 0 bei job="serve" (kein Event)

p95 (s): histogram_quantile(0.95, sum by (le) (rate(chs_dataset_export_duration_seconds_bucket[2m]))) → 2.425

Loki/MDC: (stichprobenartig) MDC-Felder vorhanden & parsebar (run_id, dataset_id, model_id, model_version, username, component).

Risiken / Follow-ups:

Result-Breakdown: ml emittiert derzeit kein result-Label → Panels für Result-Split nur dort nutzen, wo vorhanden (oder später optional additiv in A1 ergänzen).

Training-Counter: chs_training_runs_total zeigte im 10-Min-Fenster 0; prüfen, ob beim Start/Ende inkrementiert wird (kleiner Follow-up, kein A-Gate-Blocker).

Serve Dataset-Events: optional auch im serve einen /dataset/metrics Receiver anbinden, falls Exporte dort stattfinden sollen; aktuell reicht ML.

Panels-Einheiten: Dataset-Dauern in Sekunden instrumentiert → Dashboards entsprechend angepasst lassen (keine ms-Achsen).

Startempfehlung Block B: Go für B1/B2/B3.

B1 feature/model-registry-readonly (API),

B2 feature/serve-model-reload-by-version (Serving),

B3 feature/obs-predict-by-version (Obs).
Draft-PRs können vorbereitet werden; Observability derzeit belastbar.

Evidence (zum Anhängen / Einfügen)

Self-Play:

POST /selfplay/run (sync & async): smoke-sync-4 → OK, smoke-visual-1 → Live-Rate sichtbar

sum by(job,instance) (chs_selfplay_games_total) → ml:8000 = 20, serve:8001 = 0

60*sum(irate(chs_selfplay_games_total{job="ml"}[30s])) → 1140 (mehrfach), danach 0 (Run Ende)

60*sum(rate(chs_selfplay_games_total[2m])) → 110.01

Dataset:

POST /dataset/metrics (ML): dataset_id="smoke-1", rows_total=150, export_duration_seconds=1.2 → {"ok":true}

sum(chs_dataset_rows_total) → 151

Ø-Dauer (s): job="ml" → 1.2; job="serve" → 0 (kein Sample)

p95 (s): 2.425

Targets: curl /api/v1/targets → health:"up", lastError:"" (api/ml/serve/loki/prometheus).

Panel-Queries (eingesetzt)

Self-Play Games/min:
60 * sum(rate(chs_selfplay_games_total[2m]))

Self-Play Total (24h):
sum(increase(chs_selfplay_games_total[24h]))

Dataset Rows:
sum(chs_dataset_rows_total)

Dataset Ø-Dauer (s):
rate(chs_dataset_export_duration_seconds_sum[5m]) / clamp_min(rate(chs_dataset_export_duration_seconds_count[5m]), 1e-9)

Dataset p95 (s):
histogram_quantile(0.95, sum by (le) (rate(chs_dataset_export_duration_seconds_bucket[5m])))

PR-Kommentar-Snippet (für #58/#59/#60)
✅ Merged into `develop`.

DoD: 
- Targets UP (api/ml/serve), no scrape errors
- Self-Play counters & rates visible (chs_selfplay_games_total)
- Dataset metrics visible (rows total = 151, p95 = 2.425 s, mean = 1.2 s)
- Dashboards adjusted (seconds), no “No data”

Evidence:
- PromQL outputs (s.o.), Smoke run IDs: smoke-sync-4, smoke-visual-1, dataset smoke-1
- Health endpoints 200
- Loki MDC fields present (run_id, dataset_id, model_id, model_version, username, component)