### PR TITLE
Add serve smoke test and baseline documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ test: ## Run monitoring checks
 	python3 -m pip install -r infra/tests/requirements.txt
 	pytest infra/tests -q
 
-.PHONY: obs-e2e-test
+.PHONY: obs-e2e-test smoke-serve
 obs-e2e-test:
 	bash scripts/obs_e2e_test.sh
+
+smoke-serve: ## Smoke test serve and api
+	bash scripts/smoke_serve.sh

--- a/docs/devnotes/serve_baseline.md
+++ b/docs/devnotes/serve_baseline.md
@@ -1,0 +1,25 @@
+# Serve Baseline
+
+## Ports
+- FastAPI serve: `8001`
+- Spring Boot API proxy: `8080`
+
+## Endpoints
+- `GET /health` – FastAPI health check
+- `GET /metrics` – Prometheus metrics for serve
+- `POST /predict` – chess move prediction
+- `POST /models/load` – load model from S3
+- `POST /dataset/metrics` – publish dataset statistics
+- `GET /v1/health` – API proxy health
+
+## Metrics
+- `chs_predict_requests_total{username,model_id,status}`
+- `chs_predict_latency_seconds`
+- `chs_predict_illegal_requests_total`
+- `chs_dataset_rows{dataset_id}`
+- `chs_dataset_invalid_rows_total{dataset_id}`
+- `chs_dataset_export_duration_seconds`
+
+## Logging
+- serve uses `python_json_logger` and emits JSON lines
+- API uses a JSON console pattern via Spring Boot's `logging.pattern.console`

--- a/scripts/smoke_serve.sh
+++ b/scripts/smoke_serve.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Smoke test for FastAPI serve service and API proxy
+set -euo pipefail
+
+HOST="${HOST:-localhost}"
+
+# Serve health
+curl -fs "http://${HOST}:8001/health" >/dev/null
+
+# Serve metrics (optional prefix check)
+if curl -fs "http://${HOST}:8001/metrics" | grep -q '^chs_predict_'; then
+  echo "chs_predict_* metrics found"
+else
+  echo "chs_predict_* metrics missing"
+fi
+
+# API health
+curl -fs "http://${HOST}:8080/v1/health" >/dev/null
+
+echo "smoke-serve completed"


### PR DESCRIPTION
## Summary
- add `smoke_serve.sh` to verify FastAPI and API proxy endpoints
- wire `smoke-serve` target into Makefile
- document serve ports, endpoints, metrics and JSON logging

## Testing
- `make smoke-serve` *(fails: Error 7)*

------
https://chatgpt.com/codex/tasks/task_e_68b34f2a76b4832b852b02752a576133