### PR TITLE
Add reproducible E2E flow and smoke test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ Thumbs.db
 **/lib/
 .venv/
 **/__pycache__/
+data/raw/
+reports/
+junit.xml

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ test: ## Run monitoring checks
 	python3 -m pip install -r infra/tests/requirements.txt
 	pytest infra/tests -q
 
-.PHONY: obs-e2e-test smoke-serve smoke-prom
+.PHONY: obs-e2e-test smoke-serve smoke-prom e2e
 obs-e2e-test:
 	bash scripts/obs_e2e_test.sh
 
@@ -44,3 +44,7 @@ smoke-serve: ## Smoke test serve and api
 
 smoke-prom: ## Smoke test Prometheus scraping
 	bash scripts/smoke_prom.sh
+
+e2e: ## Run end-to-end flow
+	bash scripts/smoke_e2e.sh
+	E2E_OFFLINE=1 pytest e2e/tests/test_flow.py --junitxml=junit.xml -q

--- a/e2e/tests/test_flow.py
+++ b/e2e/tests/test_flow.py
@@ -1,0 +1,132 @@
+import json
+import re
+import time
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(scope="session")
+def context():
+    return {
+        "user": "e2e_user",
+        "model_id": "e2e_model",
+        "version": "v0",
+        "stages": {},
+        "metrics": {},
+    }
+
+
+@pytest.fixture(scope="session", autouse=True)
+def write_report(context):
+    yield
+    ts = time.strftime("%Y%m%d_%H%M%S")
+    report_dir = Path("reports")
+    report_dir.mkdir(exist_ok=True)
+    lines = ["# E2E Run", "", "| Stage | Duration (s) |", "|-------|--------------|"]
+    for stage, meta in context["stages"].items():
+        lines.append(f"| {stage} | {meta['duration']:.2f} |")
+    if context["metrics"]:
+        lines.extend(["", "## Metrics"])
+        for k, v in context["metrics"].items():
+            lines.append(f"- {k}: {v}")
+    (report_dir / f"e2e_run_{ts}.md").write_text("\n".join(lines))
+
+
+@pytest.fixture(scope="session")
+def client():
+    import sys
+    from pathlib import Path
+    import os
+
+    serve_dir = Path(__file__).resolve().parents[2] / "serve"
+    sys.path.insert(0, str(serve_dir))
+    os.environ.setdefault("SERVE_MODEL_ROOT", str((Path("artifacts")).resolve()))
+    from app.main import app
+
+    return TestClient(app)
+
+
+@pytest.mark.ingest
+@pytest.mark.integration
+def test_ingest_stage(context):
+    start = time.perf_counter()
+    user = context["user"]
+    base = Path(f"data/raw/{user}")
+    base.mkdir(parents=True, exist_ok=True)
+    sample = {
+        "fen": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+        "move": "e2e4",
+    }
+    (base / "games.jsonl").write_text(json.dumps(sample) + "\n")
+    context["stages"]["ingest"] = {"duration": time.perf_counter() - start}
+
+
+@pytest.mark.training
+@pytest.mark.integration
+def test_initial_training_stage(context):
+    start = time.perf_counter()
+    model_root = Path("artifacts") / context["model_id"] / context["version"]
+    model_root.mkdir(parents=True, exist_ok=True)
+    (model_root / "model.pt").write_text("fake model")
+    (model_root / "best.pt").write_text("fake model")
+    (model_root / "metrics.json").write_text(json.dumps({"acc": 0.0}))
+    context["stages"]["training"] = {"duration": time.perf_counter() - start}
+
+
+@pytest.mark.serve
+@pytest.mark.integration
+def test_serve_stage(context, client):
+    start = time.perf_counter()
+    model_id, version = context["model_id"], context["version"]
+    artifact = Path("artifacts")/model_id/version/"best.pt"
+    if artifact.exists():
+        artifact.unlink()
+    resp = client.post("/models/load", json={"modelId": model_id, "modelVersion": version})
+    assert resp.status_code == 404
+    artifact.write_text("fake model")
+    resp = client.post("/models/load", json={"modelId": model_id, "modelVersion": version})
+    assert resp.status_code == 200
+    assert resp.json()["active"]["modelId"] == model_id
+    context["stages"]["serve"] = {"duration": time.perf_counter() - start}
+
+
+@pytest.mark.predict
+@pytest.mark.integration
+def test_predict_stage(context, client):
+    start = time.perf_counter()
+    fen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+    resp = client.post("/predict", json={"fen": fen})
+    assert resp.status_code == 200
+    assert len(resp.json()["move"]) >= 4
+    bad = client.post("/predict", json={"fen": "invalid"})
+    assert bad.status_code == 400
+    context["stages"]["predict"] = {"duration": time.perf_counter() - start}
+
+
+@pytest.mark.observability
+@pytest.mark.integration
+def test_observability_stage(context, client):
+    start = time.perf_counter()
+    metrics = client.get("/metrics")
+    assert metrics.status_code == 200
+    text = metrics.text
+    assert "chs_predict_latency_ms_bucket" in text
+    ml = context["model_id"]
+    ver = context["version"]
+    assert f'chs_models_loaded_total{{model_id="{ml}",model_version="{ver}"}}' in text.replace(" ", "")
+    assert f'chs_predict_errors_total{{code="400",model_id="{ml}",model_version="{ver}"}}' in text.replace(" ", "")
+    req = re.search(
+        r'chs_predict_requests_total{model_id="[^"]+",model_version="[^"]+"} (\d+(?:\.\d+)?)',
+        text,
+    )
+    err = re.search(
+        r'chs_predict_errors_total{model_id="[^"]+",model_version="[^"]+",code="400"} (\d+(?:\.\d+)?)',
+        text,
+    )
+    context["metrics"] = {
+        "predict_requests_total": float(req.group(1)) if req else 0.0,
+        "predict_errors_total": float(err.group(1)) if err else 0.0,
+    }
+    context["stages"]["observability"] = {"duration": time.perf_counter() - start}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,9 @@
 [pytest]
 markers =
     integration: marks tests that hit live services (deselect with -m "not integration")
+    ingest: ingest stage of end-to-end flow
+    training: initial training stage
+    serve: model serving stage
+    predict: prediction stage
+    observability: metrics and monitoring stage
+    slow: marks slow tests

--- a/scripts/smoke_e2e.sh
+++ b/scripts/smoke_e2e.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Minimal end-to-end smoke covering load, predict and metrics
+set -euo pipefail
+
+export E2E_OFFLINE=${E2E_OFFLINE:-1}
+MODEL_ID="${MODEL_ID:-e2e_model}"
+MODEL_VERSION="${MODEL_VERSION:-v0}"
+PORT="${PORT:-8001}"
+export SERVE_MODEL_ROOT="$(pwd)/artifacts"
+
+# Ingest (synthetic)
+python - <<'PY'
+from pathlib import Path
+import json
+user = "e2e_user"
+base = Path(f"data/raw/{user}")
+base.mkdir(parents=True, exist_ok=True)
+sample = {"fen": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", "move": "e2e4"}
+(base / "games.jsonl").write_text(json.dumps(sample)+"\n")
+PY
+
+# Training (stub)
+python - <<PY
+from pathlib import Path
+import json
+root = Path("artifacts") / "${MODEL_ID}" / "${MODEL_VERSION}"
+root.mkdir(parents=True, exist_ok=True)
+(root/"model.pt").write_text("fake model")
+(root/"best.pt").write_text("fake model")
+(root/"metrics.json").write_text(json.dumps({"acc":0.0}))
+PY
+
+# Start serve
+python -m uvicorn serve.app.main:app --port "$PORT" >/tmp/e2e_serve.log 2>&1 &
+SERVE_PID=$!
+trap 'kill $SERVE_PID >/dev/null 2>&1 || true' EXIT
+for i in {1..10}; do
+  curl -s "http://localhost:${PORT}/health" >/dev/null 2>&1 && break
+  sleep 1
+done
+
+# Load model (seed if missing)
+LOAD_PAYLOAD="{\"modelId\":\"$MODEL_ID\",\"modelVersion\":\"$MODEL_VERSION\"}"
+code=$(curl -s -o /dev/null -w "%{http_code}" -X POST "http://localhost:${PORT}/models/load" -H "Content-Type: application/json" -d "$LOAD_PAYLOAD")
+if [ "$code" != "200" ]; then
+  python - <<PY
+from pathlib import Path
+root = Path("artifacts")/"${MODEL_ID}"/"${MODEL_VERSION}"
+root.mkdir(parents=True, exist_ok=True)
+(root/"best.pt").write_text("fake model")
+PY
+  curl -sSf -X POST "http://localhost:${PORT}/models/load" -H "Content-Type: application/json" -d "$LOAD_PAYLOAD"
+fi
+
+# Predict valid
+curl -sSf -X POST "http://localhost:${PORT}/predict" -H "Content-Type: application/json" \
+  -d '{"fen":"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"}' >/dev/null
+
+# Predict invalid (expect 400)
+code=$(curl -s -o /dev/null -w "%{http_code}" -X POST "http://localhost:${PORT}/predict" -H "Content-Type: application/json" -d '{"fen":"invalid"}')
+[ "$code" = "400" ]
+
+# Metrics check
+curl -sSf "http://localhost:${PORT}/metrics" | grep chs_predict_latency_ms_bucket >/dev/null
+
+kill $SERVE_PID
+wait $SERVE_PID 2>/dev/null || true


### PR DESCRIPTION
## Summary
- add end-to-end pytest flow covering ingest, training, serving, prediction and observability
- provide shell smoke script to exercise the minimal E2E path
- wire up `make e2e` target and stage markers

## Testing
- `make e2e`

------
https://chatgpt.com/codex/tasks/task_e_68b47b6fd4fc832b9a4e5b43bf5b326d