### PR TITLE
Implement ingest run schema and domain DTOs

### DIFF
--- a/api/src/main/java/com/chessapp/api/ingest/IngestAliasController.java
+++ b/api/src/main/java/com/chessapp/api/ingest/IngestAliasController.java
@@ -1,0 +1,21 @@
+package com.chessapp.api.ingest;
+
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@SecurityRequirement(name = "bearerAuth")
+public class IngestAliasController {
+
+    @PostMapping("/v1/data/import")
+    public ResponseEntity<Void> redirect() {
+        return ResponseEntity.status(HttpStatus.PERMANENT_REDIRECT)
+                .location(URI.create("/v1/ingest"))
+                .build();
+    }
+}

--- a/api/src/main/java/com/chessapp/api/ingest/IngestAliasController.java
+++ b/api/src/main/java/com/chessapp/api/ingest/IngestAliasController.java
@@ -1,9 +1,11 @@
 package com.chessapp.api.ingest;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,12 +15,13 @@ import java.net.URI;
 
 @RestController
 @SecurityRequirement(name = "bearerAuth")
+@Tag(name = "ingest")
 public class IngestAliasController {
 
     @PostMapping("/v1/data/import")
     @Operation(summary = "Alias – 308 redirect to /v1/ingest",
             description = "Alias – 308 \u2192 /v1/ingest", deprecated = true)
-    @ApiResponses({@ApiResponse(responseCode = "308", description = "permanent redirect")})
+    @ApiResponses({@ApiResponse(responseCode = "308", description = "permanent redirect", content = @Content())})
     public ResponseEntity<Void> redirect() {
         return ResponseEntity.status(HttpStatus.PERMANENT_REDIRECT)
                 .location(URI.create("/v1/ingest"))

--- a/api/src/main/java/com/chessapp/api/ingest/IngestAliasController.java
+++ b/api/src/main/java/com/chessapp/api/ingest/IngestAliasController.java
@@ -1,5 +1,8 @@
 package com.chessapp.api.ingest;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +16,9 @@ import java.net.URI;
 public class IngestAliasController {
 
     @PostMapping("/v1/data/import")
+    @Operation(summary = "Alias – 308 redirect to /v1/ingest",
+            description = "Alias – 308 \u2192 /v1/ingest", deprecated = true)
+    @ApiResponses({@ApiResponse(responseCode = "308", description = "permanent redirect")})
     public ResponseEntity<Void> redirect() {
         return ResponseEntity.status(HttpStatus.PERMANENT_REDIRECT)
                 .location(URI.create("/v1/ingest"))

--- a/api/src/main/java/com/chessapp/api/ingest/IngestConfig.java
+++ b/api/src/main/java/com/chessapp/api/ingest/IngestConfig.java
@@ -1,0 +1,30 @@
+package com.chessapp.api.ingest;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
+
+@Configuration
+@EnableAsync
+public class IngestConfig {
+
+    @Bean(name = {"taskExecutor", "ingestExecutor"})
+    public ThreadPoolTaskExecutor taskExecutor() {
+        ThreadPoolTaskExecutor ex = new ThreadPoolTaskExecutor();
+        ex.setCorePoolSize(4);
+        ex.setMaxPoolSize(8);
+        ex.setQueueCapacity(100);
+        ex.setThreadNamePrefix("ingest-");
+        ex.initialize();
+        return ex;
+    }
+
+    @Bean
+    public Supplier<Long> ingestSleep() {
+        return () -> ThreadLocalRandom.current().nextLong(50, 150);
+    }
+}

--- a/api/src/main/java/com/chessapp/api/ingest/IngestController.java
+++ b/api/src/main/java/com/chessapp/api/ingest/IngestController.java
@@ -4,9 +4,12 @@ import com.chessapp.api.ingest.dto.CreateIngestRequest;
 import com.chessapp.api.ingest.dto.CreateIngestResponse;
 import com.chessapp.api.ingest.dto.IngestStatusResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -17,6 +20,7 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/v1/ingest")
 @SecurityRequirement(name = "bearerAuth")
+@Tag(name = "ingest")
 public class IngestController {
 
     private final IngestService service;
@@ -28,7 +32,10 @@ public class IngestController {
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.ACCEPTED)
     @Operation(summary = "Start offline ingest", description = "Startet einen Ingest-Run (offline Slice).")
-    @ApiResponses({@ApiResponse(responseCode = "202", description = "accepted")})
+    @ApiResponses({
+            @ApiResponse(responseCode = "202", description = "accepted",
+                    content = @Content(schema = @Schema(implementation = CreateIngestResponse.class)))
+    })
     public CreateIngestResponse start(@Valid @RequestBody CreateIngestRequest request) {
         UUID runId = service.startRun(request.username(), request.range());
         return new CreateIngestResponse(runId);
@@ -36,6 +43,10 @@ public class IngestController {
 
     @GetMapping(value = "/{runId}", produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "Poll ingest run status")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "status",
+                    content = @Content(schema = @Schema(implementation = IngestStatusResponse.class)))
+    })
     public IngestStatusResponse status(@PathVariable UUID runId) {
         return service.getStatus(runId);
     }

--- a/api/src/main/java/com/chessapp/api/ingest/IngestController.java
+++ b/api/src/main/java/com/chessapp/api/ingest/IngestController.java
@@ -1,0 +1,42 @@
+package com.chessapp.api.ingest;
+
+import com.chessapp.api.ingest.dto.CreateIngestRequest;
+import com.chessapp.api.ingest.dto.CreateIngestResponse;
+import com.chessapp.api.ingest.dto.IngestStatusResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/v1/ingest")
+@SecurityRequirement(name = "bearerAuth")
+public class IngestController {
+
+    private final IngestService service;
+
+    public IngestController(IngestService service) {
+        this.service = service;
+    }
+
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    @Operation(summary = "Start offline ingest", description = "Startet einen Ingest-Run (offline Slice).")
+    @ApiResponses({@ApiResponse(responseCode = "202", description = "accepted")})
+    public CreateIngestResponse start(@Valid @RequestBody CreateIngestRequest request) {
+        UUID runId = service.startRun(request.username(), request.range());
+        return new CreateIngestResponse(runId);
+    }
+
+    @GetMapping(value = "/{runId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(summary = "Poll ingest run status")
+    public IngestStatusResponse status(@PathVariable UUID runId) {
+        return service.getStatus(runId);
+    }
+}

--- a/api/src/main/java/com/chessapp/api/ingest/IngestRunEntity.java
+++ b/api/src/main/java/com/chessapp/api/ingest/IngestRunEntity.java
@@ -1,0 +1,102 @@
+package com.chessapp.api.ingest;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity(name = "ingest_runs")
+public class IngestRunEntity {
+
+    @Id
+    private UUID id;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column
+    private String range;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private IngestRunStatus status;
+
+    @Column(name = "report_uri")
+    private String reportUri;
+
+    @Column
+    private String error;
+
+    @Column(name = "started_at", nullable = false)
+    private Instant startedAt;
+
+    @Column(name = "finished_at")
+    private Instant finishedAt;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getRange() {
+        return range;
+    }
+
+    public void setRange(String range) {
+        this.range = range;
+    }
+
+    public IngestRunStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(IngestRunStatus status) {
+        this.status = status;
+    }
+
+    public String getReportUri() {
+        return reportUri;
+    }
+
+    public void setReportUri(String reportUri) {
+        this.reportUri = reportUri;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+
+    public Instant getStartedAt() {
+        return startedAt;
+    }
+
+    public void setStartedAt(Instant startedAt) {
+        this.startedAt = startedAt;
+    }
+
+    public Instant getFinishedAt() {
+        return finishedAt;
+    }
+
+    public void setFinishedAt(Instant finishedAt) {
+        this.finishedAt = finishedAt;
+    }
+}

--- a/api/src/main/java/com/chessapp/api/ingest/IngestRunRepository.java
+++ b/api/src/main/java/com/chessapp/api/ingest/IngestRunRepository.java
@@ -1,0 +1,8 @@
+package com.chessapp.api.ingest;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface IngestRunRepository extends JpaRepository<IngestRunEntity, UUID> {}
+

--- a/api/src/main/java/com/chessapp/api/ingest/IngestRunStatus.java
+++ b/api/src/main/java/com/chessapp/api/ingest/IngestRunStatus.java
@@ -1,0 +1,8 @@
+package com.chessapp.api.ingest;
+
+public enum IngestRunStatus {
+    PENDING,
+    RUNNING,
+    SUCCEEDED,
+    FAILED
+}

--- a/api/src/main/java/com/chessapp/api/ingest/IngestService.java
+++ b/api/src/main/java/com/chessapp/api/ingest/IngestService.java
@@ -1,0 +1,90 @@
+package com.chessapp.api.ingest;
+
+import com.chessapp.api.ingest.dto.IngestStatusResponse;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.lang.Nullable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+@Service
+public class IngestService {
+
+    private static final Logger log = LoggerFactory.getLogger(IngestService.class);
+
+    private final IngestRunRepository repository;
+    private final Counter startedCounter;
+    private final Counter succeededCounter;
+    private final Counter failedCounter;
+    private final AtomicInteger activeRuns;
+    private final Supplier<Long> sleepSupplier;
+
+    public IngestService(IngestRunRepository repository, MeterRegistry registry, Supplier<Long> ingestSleep) {
+        this.repository = repository;
+        this.startedCounter = Counter.builder("chs_ingest_runs_started_total").register(registry);
+        this.succeededCounter = Counter.builder("chs_ingest_runs_succeeded_total").register(registry);
+        this.failedCounter = Counter.builder("chs_ingest_runs_failed_total").register(registry);
+        this.activeRuns = registry.gauge("chs_ingest_active_runs", new AtomicInteger(0));
+        this.sleepSupplier = ingestSleep;
+    }
+
+    public UUID startRun(String username, @Nullable String range) {
+        UUID runId = UUID.randomUUID();
+        IngestRunEntity entity = new IngestRunEntity();
+        entity.setId(runId);
+        entity.setUsername(username);
+        entity.setRange(range);
+        entity.setStatus(IngestRunStatus.RUNNING);
+        entity.setStartedAt(Instant.now());
+        repository.save(entity);
+
+        startedCounter.increment();
+        activeRuns.incrementAndGet();
+
+        try (MDC.MDCCloseable c = MDC.putCloseable("run_id", runId.toString())) {
+            log.info("ingest requested username={} range={}", username, range);
+        }
+
+        simulateIngest(runId, username, range);
+        return runId;
+    }
+
+    @Async
+    void simulateIngest(UUID runId, String username, @Nullable String range) {
+        try (MDC.MDCCloseable c = MDC.putCloseable("run_id", runId.toString())) {
+            Thread.sleep(sleepSupplier.get());
+            IngestRunEntity entity = repository.findById(runId).orElseThrow();
+            entity.setStatus(IngestRunStatus.SUCCEEDED);
+            entity.setReportUri("s3://reports/ingest/%s/report.json".formatted(runId));
+            entity.setFinishedAt(Instant.now());
+            repository.save(entity);
+            succeededCounter.increment();
+        } catch (Exception e) {
+            IngestRunEntity entity = repository.findById(runId).orElse(null);
+            if (entity != null) {
+                entity.setStatus(IngestRunStatus.FAILED);
+                entity.setError(e.getMessage());
+                entity.setFinishedAt(Instant.now());
+                repository.save(entity);
+            }
+            failedCounter.increment();
+            log.error("ingest failed", e);
+        } finally {
+            activeRuns.decrementAndGet();
+            MDC.remove("run_id");
+        }
+    }
+
+    public IngestStatusResponse getStatus(UUID runId) {
+        IngestRunEntity entity = repository.findById(runId).orElseThrow();
+        return new IngestStatusResponse(entity.getStatus().name(), entity.getReportUri());
+    }
+}

--- a/api/src/main/java/com/chessapp/api/ingest/dto/CreateIngestRequest.java
+++ b/api/src/main/java/com/chessapp/api/ingest/dto/CreateIngestRequest.java
@@ -1,7 +1,15 @@
 package com.chessapp.api.ingest.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record CreateIngestRequest(@NotBlank String username, String range) {}
+@Schema(description = "Start offline ingest", example = "{\"username\":\"alice\",\"range\":\"2025-08\"}")
+public record CreateIngestRequest(
+        @NotBlank
+        @Schema(description = "Username initiating ingest", example = "alice")
+        String username,
+
+        @Schema(description = "Optional free-form range token", example = "2025-08")
+        String range) {}

--- a/api/src/main/java/com/chessapp/api/ingest/dto/CreateIngestRequest.java
+++ b/api/src/main/java/com/chessapp/api/ingest/dto/CreateIngestRequest.java
@@ -1,6 +1,7 @@
 package com.chessapp.api.ingest.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.NotBlank;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record CreateIngestRequest(String username, String range) {}
+public record CreateIngestRequest(@NotBlank String username, String range) {}

--- a/api/src/main/java/com/chessapp/api/ingest/dto/CreateIngestRequest.java
+++ b/api/src/main/java/com/chessapp/api/ingest/dto/CreateIngestRequest.java
@@ -1,0 +1,6 @@
+package com.chessapp.api.ingest.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record CreateIngestRequest(String username, String range) {}

--- a/api/src/main/java/com/chessapp/api/ingest/dto/CreateIngestResponse.java
+++ b/api/src/main/java/com/chessapp/api/ingest/dto/CreateIngestResponse.java
@@ -1,0 +1,7 @@
+package com.chessapp.api.ingest.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.UUID;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record CreateIngestResponse(UUID runId) {}

--- a/api/src/main/java/com/chessapp/api/ingest/dto/CreateIngestResponse.java
+++ b/api/src/main/java/com/chessapp/api/ingest/dto/CreateIngestResponse.java
@@ -1,7 +1,11 @@
 package com.chessapp.api.ingest.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.UUID;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record CreateIngestResponse(UUID runId) {}
+@Schema(description = "Ingest run identifier")
+public record CreateIngestResponse(
+        @Schema(example = "123e4567-e89b-12d3-a456-426614174000")
+        UUID runId) {}

--- a/api/src/main/java/com/chessapp/api/ingest/dto/IngestStatusResponse.java
+++ b/api/src/main/java/com/chessapp/api/ingest/dto/IngestStatusResponse.java
@@ -1,6 +1,13 @@
 package com.chessapp.api.ingest.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record IngestStatusResponse(String status, String reportUri) {}
+@Schema(description = "Ingest run status response")
+public record IngestStatusResponse(
+        @Schema(description = "Current run status", example = "SUCCEEDED")
+        String status,
+
+        @Schema(description = "S3 report location if available", example = "s3://reports/ingest/<runId>/report.json")
+        String reportUri) {}

--- a/api/src/main/java/com/chessapp/api/ingest/dto/IngestStatusResponse.java
+++ b/api/src/main/java/com/chessapp/api/ingest/dto/IngestStatusResponse.java
@@ -1,0 +1,6 @@
+package com.chessapp.api.ingest.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record IngestStatusResponse(String status, String reportUri) {}

--- a/api/src/main/resources/db/migration/V4__ingest_runs.sql
+++ b/api/src/main/resources/db/migration/V4__ingest_runs.sql
@@ -1,0 +1,11 @@
+CREATE TABLE ingest_runs (
+  id UUID PRIMARY KEY,
+  username TEXT NOT NULL,
+  range TEXT NULL,
+  status TEXT NOT NULL CHECK (status IN ('PENDING','RUNNING','SUCCEEDED','FAILED')),
+  report_uri TEXT NULL,
+  error TEXT NULL,
+  started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  finished_at TIMESTAMPTZ NULL
+);
+CREATE INDEX idx_ingest_runs_started_at ON ingest_runs(started_at DESC);

--- a/api/src/test/java/com/chessapp/api/ingest/IngestControllerIT.java
+++ b/api/src/test/java/com/chessapp/api/ingest/IngestControllerIT.java
@@ -1,0 +1,122 @@
+package com.chessapp.api.ingest;
+
+import com.chessapp.api.ApiApplication;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.TestConfiguration;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+@SpringBootTest(classes = ApiApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class IngestControllerIT {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
+
+    @DynamicPropertySource
+    static void databaseProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+        registry.add("spring.flyway.enabled", () -> true);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+    }
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    TestRestTemplate rest;
+
+    private String url(String path) {
+        return "http://localhost:" + port + path;
+    }
+
+    @Test
+    void startIngest_returnsRunId() {
+        UUID runId = startRun();
+        assertThat(runId).isNotNull();
+    }
+
+    @Test
+    void pollRun_succeedsWithin2s() throws Exception {
+        UUID runId = startRun();
+
+        Instant start = Instant.now();
+        Map status;
+        do {
+            ResponseEntity<Map> res = rest.getForEntity(url("/v1/ingest/" + runId), Map.class);
+            assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+            status = res.getBody();
+            String s = String.valueOf(status.get("status"));
+            if ("SUCCEEDED".equals(s)) {
+                break;
+            }
+            assertThat(Duration.between(start, Instant.now()).toMillis()).isLessThan(2000);
+            Thread.sleep(100);
+        } while (true);
+
+        assertThat(status.get("reportUri")).isEqualTo("s3://reports/ingest/" + runId + "/report.json");
+    }
+
+    @Test
+    void dataImportAliasRedirects() {
+        ResponseEntity<Void> res = rest.postForEntity(url("/v1/data/import"), null, Void.class);
+        assertThat(res.getStatusCode()).isEqualTo(HttpStatus.PERMANENT_REDIRECT);
+        assertThat(res.getHeaders().getLocation()).hasToString("/v1/ingest");
+    }
+
+    @Test
+    void prometheusExposesMetrics() {
+        startRun();
+        String body = rest.getForObject(url("/actuator/prometheus"), String.class);
+        Pattern pattern = Pattern.compile("^chs_ingest_runs_started_total\\{.*}\\s+(\\d+(?:\\.\\d+)?)$", Pattern.MULTILINE);
+        Matcher m = pattern.matcher(body);
+        assertThat(m.find()).isTrue();
+        double val = Double.parseDouble(m.group(1));
+        assertThat(val).isGreaterThan(0.0);
+    }
+
+    private UUID startRun() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        Map<String, Object> req = Map.of("username", "alice");
+        ResponseEntity<Map> resp = rest.postForEntity(url("/v1/ingest"), new HttpEntity<>(req, headers), Map.class);
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
+        String runId = (String) resp.getBody().get("runId");
+        return UUID.fromString(runId);
+    }
+
+    @TestConfiguration
+    static class NoSleepConfig {
+        @Bean
+        Supplier<Long> ingestSleep() {
+            return () -> 0L;
+        }
+    }
+}
+

--- a/docs/API_ENDPOINTS.md
+++ b/docs/API_ENDPOINTS.md
@@ -13,10 +13,13 @@
 
 ## Ingest
 
-- `POST /v1/ingest`
-  - Body: `{"username":"<name>","from":"2025-01","to":"2025-08"}`
-- **Alias:** `POST /v1/data/import` → intern Alias auf `/v1/ingest`
-- `GET /v1/ingest/{runId}` → Status
+- `POST /v1/ingest` – Start offline ingest
+  - Request: `{ "username": "string", "range": "string?" }`
+  - Response `202`: `{ "runId": "uuid" }`
+- `GET /v1/ingest/{runId}` – Status/Report
+  - Response `200`: `{ "status": "RUNNING|SUCCEEDED|FAILED", "reportUri": "string?" }`
+- **Alias (deprecated):** `POST /v1/data/import` → `308` → `/v1/ingest`
+- Metriken: `chs_ingest_runs_started_total`, `chs_ingest_runs_succeeded_total`, `chs_ingest_runs_failed_total`, `chs_ingest_active_runs`
 
 ### Beispiel
 
@@ -24,7 +27,7 @@
 curl -sS -X POST http://localhost:8080/v1/ingest \
   -H 'Content-Type: application/json' \
   -H "Authorization: Bearer $TOKEN" \
-  -d '{"username":"demo","from":"2025-01","to":"2025-08"}'
+  -d '{"username":"demo"}'
 ```
 
 ## Datasets


### PR DESCRIPTION
## Summary
- add Flyway migration for `ingest_runs` table with status, range and timestamps
- introduce `IngestRunStatus` enum and `IngestRunEntity` JPA model
- provide ingest API DTOs for create and status responses

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.chessapp:api:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68b4dde7aa34832bb600e64d5ab30a6c