### PR TITLE
Rename legacy security configuration to avoid bean name clash

### DIFF
--- a/api/api-app/src/main/java/com/chessapp/api/config/ResourceServerConfig.java
+++ b/api/api-app/src/main/java/com/chessapp/api/config/ResourceServerConfig.java
@@ -22,7 +22,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
-public class SecurityConfig {
+public class ResourceServerConfig {
 
     @Bean
     SecurityFilterChain filterChain(HttpSecurity http) throws Exception {


### PR DESCRIPTION
## Summary
- rename outdated SecurityConfig to ResourceServerConfig to prevent duplicate `securityConfig` bean

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.5 from/to jitpack.io: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4eaeaf754832b90d65a4313809138