### PR TITLE
feat(api): secure endpoints with jwt

### DIFF
--- a/api/api-app/pom.xml
+++ b/api/api-app/pom.xml
@@ -34,6 +34,10 @@
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>

--- a/api/api-app/src/main/java/com/chessapp/api/config/SecurityConfig.java
+++ b/api/api-app/src/main/java/com/chessapp/api/config/SecurityConfig.java
@@ -1,10 +1,27 @@
 package com.chessapp.api.config;
 
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import javax.crypto.spec.SecretKeySpec;
+
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.core.convert.converter.Converter;
 
 @Configuration
 @EnableWebSecurity
@@ -15,15 +32,38 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(
-                                "/v1/**",
-                                "/actuator/**",
-                                "/swagger-ui.html",
-                                "/swagger-ui/**",
-                                "/v3/api-docs/**"
-                        ).permitAll()
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**").permitAll()
+                        .requestMatchers("/actuator/prometheus").hasRole("MONITORING")
+                        .requestMatchers("/actuator/**").authenticated()
+                        .requestMatchers("/v1/**").authenticated()
                         .anyRequest().permitAll()
-                );
+                )
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())));
         return http.build();
+    }
+
+    @Bean
+    JwtDecoder jwtDecoder(@Value("${app.security.jwt.secret}") String secret) {
+        SecretKeySpec key = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        return NimbusJwtDecoder.withSecretKey(key).build();
+    }
+
+    @Bean
+    Converter<Jwt, ? extends AbstractAuthenticationToken> jwtAuthenticationConverter() {
+        return jwt -> {
+            List<GrantedAuthority> authorities = new ArrayList<>();
+            List<String> roles = jwt.getClaimAsStringList("roles");
+            if (roles != null) {
+                roles.forEach(r -> authorities.add(new SimpleGrantedAuthority("ROLE_" + r)));
+            }
+            String scope = jwt.getClaimAsString("scope");
+            if (scope != null && !scope.isEmpty()) {
+                Arrays.stream(scope.split(" "))
+                        .forEach(s -> authorities.add(new SimpleGrantedAuthority("SCOPE_" + s)));
+            }
+            String principal = Optional.ofNullable(jwt.getClaimAsString("preferred_username"))
+                    .orElse(jwt.getClaimAsString("sub"));
+            return new JwtAuthenticationToken(jwt, authorities, principal);
+        };
     }
 }

--- a/api/api-app/src/main/resources/application.yml
+++ b/api/api-app/src/main/resources/application.yml
@@ -38,6 +38,10 @@ logging:
     org.springframework.web.reactive.function.client: INFO
   pattern:
     console: "{\"ts\":\"%d{yyyy-MM-dd'T'HH:mm:ss.SSSX}\",\"level\":\"%p\",\"logger\":\"%c{1}\",\"msg\":%m,\"run_id\":\"%X{run_id}\",\"component\":\"training\"}%n"
+app:
+  security:
+    jwt:
+      secret: ${API_JWT_SECRET:changeme}
 chs:
   default-username: ${CHESS_USERNAME:M3NG00S3}
   registry:

--- a/api/api-app/src/test/java/com/chessapp/api/it/SecurityConfigIT.java
+++ b/api/api-app/src/test/java/com/chessapp/api/it/SecurityConfigIT.java
@@ -1,0 +1,74 @@
+package com.chessapp.api.it;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.chessapp.api.testutil.AbstractIntegrationTest;
+import com.chessapp.api.testutil.JwtTestUtils;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = com.chessapp.api.codex.CodexApplication.class)
+@ActiveProfiles("codex")
+@AutoConfigureMockMvc
+class SecurityConfigIT extends AbstractIntegrationTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Value("${app.security.jwt.secret}")
+    String secret;
+
+    @Test
+    void v1_withoutToken_returns401() throws Exception {
+        mockMvc.perform(get("/v1/datasets"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void v1_withUserToken_returns200() throws Exception {
+        String token = JwtTestUtils.createToken(secret, Map.of(
+                "preferred_username", "user1",
+                "roles", List.of("USER"),
+                "scope", "api.read"));
+        mockMvc.perform(get("/v1/datasets")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void apiDocs_and_swagger_are_public() throws Exception {
+        mockMvc.perform(get("/v3/api-docs.yaml"))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/swagger-ui/index.html"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void prometheus_requires_monitoring_role() throws Exception {
+        String userToken = JwtTestUtils.createToken(secret, Map.of(
+                "sub", "user1",
+                "roles", List.of("USER")));
+        mockMvc.perform(get("/actuator/prometheus")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + userToken))
+                .andExpect(status().isForbidden());
+
+        String monitoringToken = JwtTestUtils.createToken(secret, Map.of(
+                "sub", "mon",
+                "roles", List.of("MONITORING")));
+        mockMvc.perform(get("/actuator/prometheus")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + monitoringToken))
+                .andExpect(status().isOk());
+    }
+}

--- a/api/api-app/src/test/java/com/chessapp/api/testutil/AbstractIntegrationTest.java
+++ b/api/api-app/src/test/java/com/chessapp/api/testutil/AbstractIntegrationTest.java
@@ -26,6 +26,7 @@ public abstract class AbstractIntegrationTest {
         // Prefer native Postgres enums for @Enumerated fields
         registry.add("spring.jpa.properties.hibernate.prefer_native_enum_types", () -> "true");
         registry.add("spring.jpa.properties.hibernate.type.preferred_enum_jdbc_type", () -> "postgres_enum");
+        registry.add("app.security.jwt.secret", () -> "test-secret");
     }
 }
 

--- a/api/api-app/src/test/java/com/chessapp/api/testutil/JwtTestUtils.java
+++ b/api/api-app/src/test/java/com/chessapp/api/testutil/JwtTestUtils.java
@@ -1,0 +1,29 @@
+package com.chessapp.api.testutil;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+
+public final class JwtTestUtils {
+    private JwtTestUtils() {}
+
+    public static String createToken(String secret, Map<String, Object> claims) {
+        try {
+            JWSSigner signer = new MACSigner(secret.getBytes(StandardCharsets.UTF_8));
+            JWTClaimsSet.Builder builder = new JWTClaimsSet.Builder();
+            claims.forEach(builder::claim);
+            SignedJWT jwt = new SignedJWT(new JWSHeader(JWSAlgorithm.HS256), builder.build());
+            jwt.sign(signer);
+            return jwt.serialize();
+        } catch (JOSEException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- require JWT authentication for `/v1/**` and `/actuator/**` while exposing OpenAPI docs
- restrict `/actuator/prometheus` to MONITORING role
- add HS256 JWT decoder and authority mapping

## Testing
- `mvn -q -pl api-app test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b59e1aa2a8832b9c0f0829be36a605