### PR TITLE
fix: support Python 3.12 in dataset builder

### DIFF
--- a/tools/dataset-builder/requirements.txt
+++ b/tools/dataset-builder/requirements.txt
@@ -1,6 +1,6 @@
 # Requires Python >=3.11
 python-chess==1.999
-pandas==2.1.4
+pandas==2.2.2
 pyarrow==14.0.1
 matplotlib==3.8.2
 prometheus-client==0.19.0


### PR DESCRIPTION
## Summary
- bump pandas to 2.2.2 to enable installation on Python 3.12

## Testing
- `python -m pip install -r tools/dataset-builder/requirements.txt` *(fails: Could not find a version that satisfies the requirement pandas==2.2.2 [ProxyError 403])*
- `pytest -q tools/dataset-builder/tests`


------
https://chatgpt.com/codex/tasks/task_e_68b5cd9b8adc832bab00984acdbc121a