### PR TITLE
M1 fix: activate test profile for JDBC repository tests

### DIFF
--- a/api/api-app/src/test/java/com/chessapp/db/DbJdbcTestBase.java
+++ b/api/api-app/src/test/java/com/chessapp/db/DbJdbcTestBase.java
@@ -2,7 +2,9 @@ package com.chessapp.db;
 
 import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.test.context.ActiveProfiles;
 
 @DataJdbcTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
 public abstract class DbJdbcTestBase {}


### PR DESCRIPTION
## Summary
- ensure JDBC repository tests use Testcontainers by annotating DbJdbcTestBase with `@ActiveProfiles("test")`

## Testing
- `mvn -q -f api/api-app/pom.xml test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d0084910832bb0f09096e85f8351