### PR TITLE
feat: align dataset api with db schema and logging

### DIFF
--- a/api/api-app/pom.xml
+++ b/api/api-app/pom.xml
@@ -122,6 +122,12 @@
             <artifactId>flyway-database-postgresql</artifactId>
             <version>${flyway.version}</version>
         </dependency>
+        <!-- Ermöglicht sauberes Simulieren authentifizierter Requests im MockMvc -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>

--- a/api/api-app/src/main/java/com/chessapp/api/web/DatasetController.java
+++ b/api/api-app/src/main/java/com/chessapp/api/web/DatasetController.java
@@ -1,26 +1,30 @@
 package com.chessapp.api.web;
 
+import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 
-import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import com.chessapp.api.service.DatasetService;
 import com.chessapp.api.service.dto.DatasetCreateRequest;
 import com.chessapp.api.service.dto.DatasetResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/v1/datasets")
+@Tag(name = "Datasets")
 public class DatasetController {
 
     private final DatasetService datasetService;
@@ -30,18 +34,25 @@ public class DatasetController {
     }
 
     @PostMapping
-    @ResponseStatus(HttpStatus.CREATED)
-    public DatasetResponse create(@Valid @RequestBody DatasetCreateRequest request) {
-        return datasetService.create(request);
+    @Operation(summary = "Create dataset")
+    public ResponseEntity<DatasetResponse> create(@Valid @RequestBody DatasetCreateRequest request) {
+        DatasetResponse resp = datasetService.create(request);
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(resp.getId())
+                .toUri();
+        return ResponseEntity.created(location).body(resp);
     }
 
     @GetMapping
+    @Operation(summary = "List datasets")
     public List<DatasetResponse> list(@RequestParam(defaultValue = "50") int limit,
                                       @RequestParam(defaultValue = "0") int offset) {
         return datasetService.list(limit, offset);
     }
 
     @GetMapping("/{id}")
+    @Operation(summary = "Get dataset by id")
     public DatasetResponse get(@PathVariable UUID id) {
         return datasetService.get(id);
     }

--- a/api/api-app/src/test/java/com/chessapp/api/datasets/DatasetsApiDiagnosticsIT.java
+++ b/api/api-app/src/test/java/com/chessapp/api/datasets/DatasetsApiDiagnosticsIT.java
@@ -1,0 +1,146 @@
+package com.chessapp.api.datasets;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.*;
+import org.slf4j.LoggerFactory;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import java.time.Instant;
+import java.util.*;
+import java.util.regex.Pattern;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import org.springframework.test.context.ActiveProfiles;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Diagnostic, self-explaining Integration Test for /v1/datasets.
+ * Fails with rich messages that tell you exactly what broke.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class DatasetsApiDiagnosticsIT {
+  @Autowired MockMvc mvc;
+  @Autowired ObjectMapper om;
+  static UUID datasetId; static String createdAtStr;
+  static ListAppender<ILoggingEvent> appender; static Logger rootLogger;
+  @BeforeAll static void attachLogCaptor(){ var ctx=(LoggerContext)LoggerFactory.getILoggerFactory();
+    rootLogger=ctx.getLogger("ROOT"); appender=new ListAppender<>(); appender.start(); rootLogger.addAppender(appender);} 
+  @AfterAll static void detachLogCaptor(){ if(rootLogger!=null&&appender!=null) rootLogger.detachAppender(appender); }
+
+  @Test @Order(1) @WithMockUser(username="test-user",roles={"USER"})
+  void create_shouldReturn201_withLocation_andBodyShape() throws Exception {
+    var payload = new LinkedHashMap<String,Object>();
+    payload.put("name","mini-ds"); payload.put("version","v1");
+    payload.put("filter", Map.of("keep", List.of("rated")));
+    payload.put("split", Map.of("train",0.8,"val",0.2));
+    String body = om.writeValueAsString(payload);
+    MvcResult res = mvc.perform(post("/v1/datasets")
+        .contentType(MediaType.APPLICATION_JSON).content(body))
+      .andExpect(status().isCreated()).andReturn();
+    String resp = res.getResponse().getContentAsString();
+    String location = res.getResponse().getHeader("Location");
+    SoftAssertions softly = new SoftAssertions();
+    softly.assertThat(location).withFailMessage("Missing/empty Location. Headers=%s\nBody=%s",
+        headersPretty(res), resp).isNotBlank();
+    JsonNode json = om.readTree(resp);
+    softly.assertThat(json.hasNonNull("id")).withFailMessage("Missing 'id'. Body:\n%s", pretty(resp)).isTrue();
+    if(json.hasNonNull("id")){
+      softly.assertThat(Pattern.compile("^[0-9a-fA-F-]{36}$").matcher(json.get("id").asText()).matches())
+        .withFailMessage("'id' not UUID. id=%s\nBody:\n%s", json.get("id").asText(), pretty(resp)).isTrue();
+      datasetId = UUID.fromString(json.get("id").asText());
+    }
+    softly.assertThat(json.hasNonNull("createdAt"))
+      .withFailMessage("Missing 'createdAt'. Body:\n%s", pretty(resp)).isTrue();
+    if(json.hasNonNull("createdAt")){ createdAtStr=json.get("createdAt").asText();
+      try{ Instant.parse(createdAtStr);}catch(Exception e){
+        softly.fail("'createdAt' not ISO-8601. createdAt=%s\nError=%s\nBody:\n%s",
+          createdAtStr,e.toString(),pretty(resp));}}
+    softly.assertThat(json.path("name").asText(null)).isEqualTo(payload.get("name"))
+      .withFailMessage("'name' not echoed. expected=%s actual=%s\nBody:\n%s",
+        payload.get("name"), json.path("name").asText(), pretty(resp));
+
+    if(location!=null && datasetId!=null){
+      softly.assertThat(location.endsWith("/v1/datasets/"+datasetId))
+        .withFailMessage("Location mismatch. expected suffix=/v1/datasets/%s actual=%s",
+          datasetId, location).isTrue();}
+    boolean hasDatasetMdc = appender.list.stream().anyMatch(ev ->
+      datasetId!=null && datasetId.toString().equals(ev.getMDCPropertyMap().get("dataset_id")));
+    softly.assertThat(hasDatasetMdc)
+      .withFailMessage("No log with MDC dataset_id=%s. Captured=%d. Tip: set MDC in create-path and keep JSON logging.", datasetId, appender.list.size()).isTrue();
+    softly.assertAll();
+  }
+
+  @Test @Order(2) @WithMockUser(username="test-user",roles={"USER"})
+  void getById_shouldReturn200_andConsistentBody() throws Exception {
+    assumeCreated();
+    MvcResult res = mvc.perform(get("/v1/datasets/{id}", datasetId))
+      .andExpect(status().isOk()).andReturn();
+    String resp = res.getResponse().getContentAsString();
+    JsonNode json = om.readTree(resp); SoftAssertions softly = new SoftAssertions();
+    softly.assertThat(json.path("id").asText(null)).isEqualTo(datasetId.toString())
+      .withFailMessage("GET id mismatch. expected=%s actual=%s\nBody:\n%s",
+        datasetId, json.path("id").asText(), pretty(resp));
+    softly.assertThat(json.path("createdAt").asText(null)).isNotBlank()
+      .withFailMessage("GET missing 'createdAt'. Body:\n%s", pretty(resp));
+    softly.assertAll();
+  }
+
+  @Test @Order(3) @WithMockUser(username="test-user",roles={"USER"})
+  void list_shouldBeSortedByCreatedAtDesc() throws Exception {
+    assumeCreated();
+    MvcResult res = mvc.perform(get("/v1/datasets?limit=5&offset=0"))
+      .andExpect(status().isOk()).andReturn();
+    String resp = res.getResponse().getContentAsString();
+    JsonNode json = om.readTree(resp); SoftAssertions softly = new SoftAssertions();
+    softly.assertThat(json.isArray()).withFailMessage("List should be array. Body:\n%s", pretty(resp)).isTrue();
+    boolean contains=false; Instant prev=null;
+    for(JsonNode item:json){
+      if(item.path("id").asText("").equals(String.valueOf(datasetId))) contains=true;
+      if(item.hasNonNull("createdAt")){
+        Instant cur=Instant.parse(item.get("createdAt").asText());
+        if(prev!=null){ softly.assertThat(!cur.isAfter(prev))
+          .withFailMessage("Not sorted desc: %s after %s.\nBody:\n%s", cur, prev, pretty(resp)).isTrue();}
+        prev=cur;}}
+    softly.assertThat(contains).withFailMessage("List doesn't contain created id=%s.\nBody:\n%s", datasetId, pretty(resp)).isTrue();
+    softly.assertAll();
+  }
+
+  @Test @Order(4)
+  void openapi_shouldExposeDatasetEndpoints() throws Exception {
+    MvcResult res = mvc.perform(get("/v3/api-docs")).andExpect(status().isOk()).andReturn();
+    String resp = res.getResponse().getContentAsString();
+    JsonNode api = om.readTree(resp); JsonNode paths = api.get("paths");
+    List<String> datasetPaths = new ArrayList<>(); paths.fieldNames().forEachRemaining(p->{ if(p.startsWith("/v1/datasets")) datasetPaths.add(p);});
+    // We have two dataset paths (collection + item) but three operations (GET/POST + GET)
+    // Ensure at least both paths are present.
+    assertThat(datasetPaths).withFailMessage("OpenAPI missing dataset endpoints. Need paths: collection & item. Actual: %s\nAll paths: %d",
+      datasetPaths, paths.size()).hasSizeGreaterThanOrEqualTo(2);
+  }
+
+  @Test @Order(5)
+  void unauthenticated_shouldBeRejected() throws Exception {
+    int code = mvc.perform(get("/v1/datasets")).andReturn().getResponse().getStatus();
+    assertThat(code==401 || code==403).withFailMessage("Expected 401/403 for missing auth, got %s", code).isTrue();
+  }
+
+  // helpers …
+  private static void assumeCreated(){ assertThat(datasetId).withFailMessage("No dataset id – create() failed?").isNotNull();
+    assertThat(createdAtStr).withFailMessage("No createdAt – create() failed?").isNotNull();}
+  private static String pretty(String json){ try{ var om=new ObjectMapper(); return om.writerWithDefaultPrettyPrinter().writeValueAsString(om.readTree(json)); }catch(Exception e){ return json; } }
+  private static String headersPretty(MvcResult res){ var names=res.getResponse().getHeaderNames(); var sb=new StringBuilder("{"); boolean first=true;
+    for(String n:names){ if(!first) sb.append(", "); first=false; sb.append(n).append("=").append(res.getResponse().getHeaders(n)); } sb.append("}"); return sb.toString();}
+}

--- a/api/api-app/src/test/java/com/chessapp/api/it/DatasetIT.java
+++ b/api/api-app/src/test/java/com/chessapp/api/it/DatasetIT.java
@@ -1,0 +1,99 @@
+package com.chessapp.api.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.chessapp.api.codex.CodexApplication;
+import com.chessapp.api.service.DatasetService;
+import com.chessapp.api.support.JwtTestUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = CodexApplication.class)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class DatasetIT {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Value("${app.security.jwt.secret}")
+    String secret;
+
+    @Test
+    void create_get_list_and_logs() throws Exception {
+        String token = JwtTestUtils.signHmac256(secret, Map.of(
+                "preferred_username", "user1",
+                "roles", List.of("USER"),
+                "scope", "api.write"), Duration.ofMinutes(5));
+
+        Logger logger = (Logger) org.slf4j.LoggerFactory.getLogger(DatasetService.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+
+        String payload = """
+            {"name":"ds1","version":"v1","filter":{"src":"x"},"split":{"train":1.0},"sizeRows":1}
+            """;
+
+        MvcResult result = mockMvc.perform(post("/v1/datasets")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, org.hamcrest.Matchers.matchesPattern(".*/v1/datasets/.*")))
+                .andExpect(jsonPath("$.id").isNotEmpty())
+                .andReturn();
+
+        JsonNode node = objectMapper.readTree(result.getResponse().getContentAsString());
+        String id = node.get("id").asText();
+        String location = result.getResponse().getHeader(HttpHeaders.LOCATION);
+        assertThat(location).endsWith("/v1/datasets/" + id);
+
+        boolean logHasDatasetId = appender.list.stream()
+                .anyMatch(ev -> id.equals(ev.getMDCPropertyMap().get("dataset_id"))
+                        && "api".equals(ev.getMDCPropertyMap().get("component"))
+                        && "user1".equals(ev.getMDCPropertyMap().get("username")));
+        assertThat(logHasDatasetId).isTrue();
+        logger.detachAppender(appender);
+
+        mockMvc.perform(get("/v1/datasets/" + id)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(id));
+
+        mockMvc.perform(get("/v1/datasets")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(id));
+
+        mockMvc.perform(post("/v1/datasets")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/api/api-app/src/test/java/com/chessapp/api/it/OpenApiIT.java
+++ b/api/api-app/src/test/java/com/chessapp/api/it/OpenApiIT.java
@@ -41,7 +41,10 @@ class OpenApiIT extends com.chessapp.api.testutil.AbstractIntegrationTest {
         ObjectMapper mapper = new ObjectMapper();
         JsonNode root = mapper.readTree(body);
         assertThat(root.has("openapi")).isTrue();
-        assertThat(root.path("paths").isObject()).isTrue();
+        JsonNode paths = root.path("paths");
+        assertThat(paths.isObject()).isTrue();
+        assertThat(paths.has("/v1/datasets")).isTrue();
+        assertThat(paths.has("/v1/datasets/{id}")).isTrue();
     }
 }
 

--- a/api/api-app/src/test/resources/application-test.yml
+++ b/api/api-app/src/test/resources/application-test.yml
@@ -1,15 +1,28 @@
 spring:
+  main:
+    allow-bean-definition-overriding: true
   datasource:
-    url: jdbc:tc:postgresql:16:///chsapp?TC_TMPFS=/var/lib/postgresql/data:rw
-  flyway:
-    enabled: true
-    locations: classpath:db/migration
-app:
-  security:
-    jwt:
-      secret: 0123456789abcdef0123456789abcdef
-  cors:
-    allowed-origins: http://localhost:5173
-# disable rate limiting during tests
-ratelimit:
-  enabled: false
+    url: jdbc:tc:postgresql:16-alpine:///chessapp?TC_TMPFS=/var/lib/postgresql/data:rw
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.orm.jdbc.bind: trace
+    org.springframework.jdbc.core: debug
+
+server:
+  error:
+    include-exception: true
+    include-message: always
+    include-binding-errors: always
+    include-stacktrace: always
+
+rate:
+  limit:
+    enabled: false

--- a/api/api-domain/src/main/java/com/chessapp/api/domain/entity/Dataset.java
+++ b/api/api-domain/src/main/java/com/chessapp/api/domain/entity/Dataset.java
@@ -24,11 +24,11 @@ public class Dataset {
     private String version;
 
     @Type(JsonType.class)
-    @Column(columnDefinition = "jsonb")
+    @Column(columnDefinition = "jsonb", nullable = false)
     private Map<String, Object> filter;
 
     @Type(JsonType.class)
-    @Column(columnDefinition = "jsonb")
+    @Column(columnDefinition = "jsonb", nullable = false)
     private Map<String, Object> split;
 
     @Column(name = "size_rows")
@@ -37,7 +37,7 @@ public class Dataset {
     @Column(name = "location_uri")
     private String locationUri;
 
-    @Column(name = "created_at")
+    @Column(name = "created_at", nullable = false)
     private Instant createdAt;
 
     // getters and setters

--- a/api/api-domain/src/main/java/com/chessapp/api/domain/entity/DatasetEntity.java
+++ b/api/api-domain/src/main/java/com/chessapp/api/domain/entity/DatasetEntity.java
@@ -10,10 +10,12 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import com.vladmihalcea.hibernate.type.json.JsonType;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "datasets")
-public class Dataset {
+public class DatasetEntity {
     @Id
     private UUID id;
 

--- a/api/api-domain/src/main/java/com/chessapp/api/domain/repo/DatasetRepository.java
+++ b/api/api-domain/src/main/java/com/chessapp/api/domain/repo/DatasetRepository.java
@@ -4,7 +4,7 @@ import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.chessapp.api.domain.entity.Dataset;
+import com.chessapp.api.domain.entity.DatasetEntity;
 
-public interface DatasetRepository extends JpaRepository<Dataset, UUID> {
+public interface DatasetRepository extends JpaRepository<DatasetEntity, UUID> {
 }

--- a/api/api-service/pom.xml
+++ b/api/api-service/pom.xml
@@ -45,6 +45,11 @@
             <version>${chesslib.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>2.2.22</version>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>

--- a/api/api-service/src/main/java/com/chessapp/api/service/DatasetMapper.java
+++ b/api/api-service/src/main/java/com/chessapp/api/service/DatasetMapper.java
@@ -1,10 +1,10 @@
 package com.chessapp.api.service;
 
-import com.chessapp.api.domain.entity.Dataset;
+import com.chessapp.api.domain.entity.DatasetEntity;
 import com.chessapp.api.service.dto.DatasetResponse;
 
 public class DatasetMapper {
-    public static DatasetResponse toDto(Dataset dataset) {
+    public static DatasetResponse toDto(DatasetEntity dataset) {
         return new DatasetResponse(
                 dataset.getId(),
                 dataset.getName(),

--- a/api/api-service/src/main/java/com/chessapp/api/service/DatasetService.java
+++ b/api/api-service/src/main/java/com/chessapp/api/service/DatasetService.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -57,8 +58,8 @@ public class DatasetService {
         d.setId(id);
         d.setName(req.getName());
         d.setVersion(req.getVersion());
-        d.setFilter(req.getFilter());
-        d.setSplit(req.getSplit());
+        d.setFilter(req.getFilter() != null ? req.getFilter() : Map.of());
+        d.setSplit(req.getSplit() != null ? req.getSplit() : Map.of());
         long rows = req.getSizeRows() != null ? req.getSizeRows() : 0L;
         d.setSizeRows(rows);
         d.setCreatedAt(Instant.now());
@@ -92,8 +93,7 @@ public class DatasetService {
         }
 
         try (MDC.MDCCloseable c1 = MDC.putCloseable("dataset_id", id.toString());
-             MDC.MDCCloseable c2 = MDC.putCloseable("event", "dataset.created");
-             MDC.MDCCloseable c3 = MDC.putCloseable("component", "dataset")) {
+             MDC.MDCCloseable c2 = MDC.putCloseable("event", "dataset.created")) {
             log.info("dataset created");
         }
 
@@ -102,7 +102,8 @@ public class DatasetService {
 
     @Transactional(readOnly = true)
     public List<DatasetResponse> list(int limit, int offset) {
-        return datasetRepository.findAll(PageRequest.of(offset / limit, limit))
+        return datasetRepository.findAll(PageRequest.of(offset / limit, limit,
+                        Sort.by(Sort.Direction.DESC, "createdAt")))
                 .stream()
                 .map(DatasetMapper::toDto)
                 .toList();

--- a/api/api-service/src/main/java/com/chessapp/api/service/DatasetService.java
+++ b/api/api-service/src/main/java/com/chessapp/api/service/DatasetService.java
@@ -15,7 +15,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.chessapp.api.domain.entity.Dataset;
+import com.chessapp.api.domain.entity.DatasetEntity;
 import com.chessapp.api.domain.repo.DatasetRepository;
 import com.chessapp.api.service.dto.DatasetCreateRequest;
 import com.chessapp.api.service.dto.DatasetResponse;
@@ -54,7 +54,7 @@ public class DatasetService {
         UUID id = UUID.randomUUID();
         final String key = id + "/manifest.json";
         final String locationUri = "s3://datasets/" + key;
-        Dataset d = new Dataset();
+        DatasetEntity d = new DatasetEntity();
         d.setId(id);
         d.setName(req.getName());
         d.setVersion(req.getVersion());

--- a/api/api-service/src/main/java/com/chessapp/api/service/dto/DatasetCreateRequest.java
+++ b/api/api-service/src/main/java/com/chessapp/api/service/dto/DatasetCreateRequest.java
@@ -2,11 +2,29 @@ package com.chessapp.api.service.dto;
 
 import java.util.Map;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(name = "DatasetCreateRequest")
 public class DatasetCreateRequest {
+    @NotBlank
+    @Schema(example = "sample_ds")
     private String name;
+
+    @NotBlank
+    @Schema(example = "v1")
     private String version;
+
+    @NotNull
+    @Schema(description = "filter parameters")
     private Map<String, Object> filter;
+
+    @NotNull
+    @Schema(description = "split ratios")
     private Map<String, Object> split;
+
+    @Schema(description = "number of rows")
     private Long sizeRows;
 
     public DatasetCreateRequest() {

--- a/api/api-service/src/main/java/com/chessapp/api/service/dto/DatasetResponse.java
+++ b/api/api-service/src/main/java/com/chessapp/api/service/dto/DatasetResponse.java
@@ -3,11 +3,17 @@ package com.chessapp.api.service.dto;
 import java.time.Instant;
 import java.util.UUID;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "DatasetResponse")
 public class DatasetResponse {
+    @Schema(example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")
     private UUID id;
     private String name;
     private String version;
+    @Schema(description = "number of rows")
     private Long sizeRows;
+    @Schema(description = "S3 URI of manifest")
     private String locationUri;
     private Instant createdAt;
 

--- a/scripts/accept_datasets.sh
+++ b/scripts/accept_datasets.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:8080}"
+TOKEN="${TOKEN:-test-token}"   # SEC-01 Test-Token
+AUTH_HEADER="Authorization: Bearer ${TOKEN}"
+
+jq -V >/dev/null 2>&1 || { echo "jq ist erforderlich"; exit 1; }
+
+echo "== Create =="
+CREATE_PAYLOAD='{"name":"mini-ds","filter":{"keep":["rated"]},"split":{"train":0.8,"val":0.2}}'
+resp=$(curl -fsS -X POST "$BASE_URL/v1/datasets" \
+  -H "Content-Type: application/json" -H "$AUTH_HEADER" \
+  -d "$CREATE_PAYLOAD")
+id=$(echo "$resp" | jq -r '.id')
+test "$id" != "null"
+
+loc=$(curl -i -s -X POST "$BASE_URL/v1/datasets" \
+  -H "Content-Type: application/json" -H "$AUTH_HEADER" \
+  -d "$CREATE_PAYLOAD" | awk '/^Location:/ {print $2}' | tr -d '\r')
+test -n "$loc"
+
+echo "== Get by id =="
+got=$(curl -fsS -H "$AUTH_HEADER" "$BASE_URL/v1/datasets/$id")
+test "$(echo "$got" | jq -r '.id')" = "$id"
+
+echo "== List (paged, createdAt desc) =="
+list=$(curl -fsS -H "$AUTH_HEADER" "$BASE_URL/v1/datasets?page=0&size=5&sort=createdAt,desc")
+echo "$list" | jq -e '.content | length >= 1' >/dev/null
+
+echo "== OpenAPI exposes 3 endpoints =="
+api=$(curl -fsS -H "$AUTH_HEADER" "$BASE_URL/v3/api-docs")
+paths=$(echo "$api" | jq -r '.paths | keys[]' | grep '^/v1/datasets' | wc -l | tr -d ' ')
+test "$paths" -ge 3
+
+echo "== Negative: missing auth =="
+set +e
+code=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/v1/datasets")
+set -e
+[[ "$code" == "401" || "$code" == "403" ]]
+
+echo "ALL CHECKS PASSED ✅"


### PR DESCRIPTION
## Summary
- map dataset entity fields to DB-01 schema and enforce JSONB columns
- return Location header and add OpenAPI tags for dataset endpoints
- validate dataset requests and ensure logs include dataset_id
- add dataset API integration test and OpenAPI coverage

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e6f72b44832b92bed3a48d6aaa10