### PR TITLE
fix: adjust ingest month columns to integer

### DIFF
--- a/api/api-app/src/main/resources/db/migration/V1_2__ingest_months_integer.sql
+++ b/api/api-app/src/main/resources/db/migration/V1_2__ingest_months_integer.sql
@@ -1,0 +1,3 @@
+ALTER TABLE ingest_runs
+    ALTER COLUMN from_month TYPE integer USING from_month::integer,
+    ALTER COLUMN to_month TYPE integer USING to_month::integer;


### PR DESCRIPTION
## Summary
- fix column type mismatch for ingest_runs month fields

## Testing
- `mvn -q -pl api-app -am test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6443eee90832bb1d44d87713a3cb2