### PR TITLE
Add observability proxy service

### DIFF
--- a/Makefile.obs
+++ b/Makefile.obs
@@ -1,0 +1,19 @@
+COMPOSE_BASE=infra/compose.yml
+COMPOSE_OBS=infra/compose.obs-proxy.yml
+
+obs-up:
+@if [ -f $(COMPOSE_BASE) ]; then \
+  docker compose -f $(COMPOSE_BASE) -f $(COMPOSE_OBS) up -d obs-proxy; \
+else \
+  docker compose -f $(COMPOSE_OBS) up -d obs-proxy; \
+fi
+
+obs-down:
+@if [ -f $(COMPOSE_BASE) ]; then \
+  docker compose -f $(COMPOSE_BASE) -f $(COMPOSE_OBS) down; \
+else \
+  docker compose -f $(COMPOSE_OBS) down; \
+fi
+
+obs-logs:
+docker logs -f obs-proxy

--- a/docs/OBSERVABILITY_PROXY.md
+++ b/docs/OBSERVABILITY_PROXY.md
@@ -1,0 +1,31 @@
+# Observability Proxy (M6)
+
+Zweck: Read-only Proxy, damit das Vue-Frontend Prometheus & Loki ohne Grafana direkt abfragen kann. Keine Änderungen an /api/** oder bestehenden Dashboards.
+
+## Endpunkte
+GET /healthz
+GET /obs/prom/query?query=<promql>
+GET /obs/prom/range?query=<promql>&start=<rfc3339|unix>&end=<...>&step=<duration>
+GET /obs/loki/query?query=<logql>&limit=&direction=&start=&end=
+GET /obs/loki/range?query=<logql>&limit=&direction=&start=&end=
+
+Security: optionaler Header `X-Obs-Api-Key` (env `OBS_API_KEY`).
+
+Rate-Limit: standardmäßig 60/min pro IP (env `RATE_LIMIT`), CORS: `CORS_ALLOW_ORIGINS` (CSV).
+
+Timeout/Retry: timeout=3s, retries=2 (5xx/Timeout).
+
+## ENV
+PROM_BASE_URL, LOKI_BASE_URL, OBS_API_KEY, CORS_ALLOW_ORIGINS, RATE_LIMIT, TIMEOUT_SECONDS, RETRIES.
+
+## Compose
+Siehe infra/compose.obs-proxy.yml; Start: `make -f Makefile.obs obs-up`.
+
+## Beispiel-Queries
+curl -H "X-Obs-Api-Key: $OBS_API_KEY" "http://localhost:8088/obs/prom/query?query=up"
+curl -H "X-Obs-Api-Key: $OBS_API_KEY" "http://localhost:8088/obs/loki/query?query={app=\"api\"}"
+
+## DoD / Smoke
+- Prom Range-Query liefert Daten via Proxy.
+- Loki Query (Label-Filter z. B. {component=\"training\"}) liefert Daten via Proxy.
+- Dashboards unter infra/grafana/dashboards/obs/ importierbar (UIDs obs-*-v1).

--- a/gateway/obs-proxy/Dockerfile
+++ b/gateway/obs-proxy/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY *.py .
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8088"]

--- a/gateway/obs-proxy/app.py
+++ b/gateway/obs-proxy/app.py
@@ -1,0 +1,138 @@
+import logging
+import time
+from typing import Optional
+
+from fastapi import Depends, FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from pythonjsonlogger import jsonlogger
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+
+from .config import get_settings
+from .security import client_ip, require_api_key
+from .proxy_clients import forward_get, loki_client, prom_client
+
+settings = get_settings()
+
+logger = logging.getLogger("obs-proxy")
+handler = logging.StreamHandler()
+handler.setFormatter(jsonlogger.JsonFormatter())
+logger.addHandler(handler)
+logger.setLevel(settings.LOG_LEVEL)
+
+limiter = Limiter(key_func=client_ip, default_limits=[settings.RATE_LIMIT])
+
+app = FastAPI(title="ChessApp Obs Proxy", version="v1", root_path="")
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+origins = [o.strip() for o in settings.CORS_ALLOW_ORIGINS.split(",") if o.strip()]
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_methods=["GET"],
+    allow_headers=["*"],
+)
+
+
+@app.middleware("http")
+async def log_requests(request: Request, call_next):
+    start = time.time()
+    response = await call_next(request)
+    duration_ms = (time.time() - start) * 1000
+    logger.info(
+        "request",
+        extra={
+            "method": request.method,
+            "path": request.url.path,
+            "status": response.status_code,
+            "duration_ms": round(duration_ms, 2),
+        },
+    )
+    return response
+
+
+enforce_key = require_api_key
+
+
+@app.get("/healthz")
+async def healthz():
+    return {"status": "ok"}
+
+
+# Prometheus
+@app.get("/obs/prom/query", dependencies=[Depends(enforce_key)])
+@limiter.limit(settings.RATE_LIMIT)
+async def prom_query(query: str):
+    settings = get_settings()
+    async with prom_client(settings) as client:
+        status, data, headers = await forward_get(client, "/api/v1/query", {"query": query})
+    return JSONResponse(content=data, status_code=status, headers=headers)
+
+
+@app.get("/obs/prom/range", dependencies=[Depends(enforce_key)])
+@limiter.limit(settings.RATE_LIMIT)
+async def prom_range(query: str, start: str, end: str, step: str):
+    settings = get_settings()
+    params = {"query": query, "start": start, "end": end, "step": step}
+    async with prom_client(settings) as client:
+        status, data, headers = await forward_get(client, "/api/v1/query_range", params)
+    return JSONResponse(content=data, status_code=status, headers=headers)
+
+
+# Loki
+@app.get("/obs/loki/query", dependencies=[Depends(enforce_key)])
+@limiter.limit(settings.RATE_LIMIT)
+async def loki_query(
+    query: str,
+    limit: Optional[int] = None,
+    direction: Optional[str] = None,
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+):
+    settings = get_settings()
+    params = {"query": query}
+    if limit is not None:
+        params["limit"] = limit
+    if direction is not None:
+        params["direction"] = direction
+    if start is not None:
+        params["start"] = start
+    if end is not None:
+        params["end"] = end
+    async with loki_client(settings) as client:
+        status, data, headers = await forward_get(client, "/loki/api/v1/query", params)
+    return JSONResponse(content=data, status_code=status, headers=headers)
+
+
+@app.get("/obs/loki/range", dependencies=[Depends(enforce_key)])
+@limiter.limit(settings.RATE_LIMIT)
+async def loki_range(
+    query: str,
+    limit: Optional[int] = None,
+    direction: Optional[str] = None,
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+):
+    settings = get_settings()
+    params = {"query": query}
+    if limit is not None:
+        params["limit"] = limit
+    if direction is not None:
+        params["direction"] = direction
+    if start is not None:
+        params["start"] = start
+    if end is not None:
+        params["end"] = end
+    async with loki_client(settings) as client:
+        status, data, headers = await forward_get(
+            client, "/loki/api/v1/query_range", params
+        )
+    return JSONResponse(content=data, status_code=status, headers=headers)
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("app:app", host="0.0.0.0", port=8088)

--- a/gateway/obs-proxy/config.py
+++ b/gateway/obs-proxy/config.py
@@ -1,0 +1,20 @@
+from functools import lru_cache
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    PROM_BASE_URL: str
+    LOKI_BASE_URL: str
+    OBS_API_KEY: str | None = None
+    CORS_ALLOW_ORIGINS: str = "http://localhost:5173"
+    RATE_LIMIT: str = "60/minute"
+    TIMEOUT_SECONDS: float = 3.0
+    RETRIES: int = 2
+    LOG_LEVEL: str = "INFO"
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/gateway/obs-proxy/proxy_clients.py
+++ b/gateway/obs-proxy/proxy_clients.py
@@ -1,0 +1,43 @@
+import asyncio
+from typing import Any, Dict, Tuple
+
+import httpx
+
+from .config import Settings
+
+
+def prom_client(settings: Settings) -> httpx.AsyncClient:
+    client = httpx.AsyncClient(
+        base_url=settings.PROM_BASE_URL, timeout=settings.TIMEOUT_SECONDS
+    )
+    client._retries = settings.RETRIES
+    client._upstream = "prom"
+    return client
+
+
+def loki_client(settings: Settings) -> httpx.AsyncClient:
+    client = httpx.AsyncClient(
+        base_url=settings.LOKI_BASE_URL, timeout=settings.TIMEOUT_SECONDS
+    )
+    client._retries = settings.RETRIES
+    client._upstream = "loki"
+    return client
+
+
+async def forward_get(
+    client: httpx.AsyncClient, path: str, params: Dict[str, Any]
+) -> Tuple[int, Dict[str, Any], Dict[str, str]]:
+    retries = getattr(client, "_retries", 0)
+    upstream = getattr(client, "_upstream", "")
+    for attempt in range(retries + 1):
+        try:
+            response = await client.get(path, params=params)
+            if response.status_code >= 500 and attempt < retries:
+                await asyncio.sleep(0.2 * (2 ** attempt))
+                continue
+            return response.status_code, response.json(), dict(response.headers)
+        except (httpx.RequestError, httpx.TimeoutException) as exc:
+            if attempt < retries:
+                await asyncio.sleep(0.2 * (2 ** attempt))
+                continue
+            return 502, {"error": str(exc), "upstream": upstream}, {}

--- a/gateway/obs-proxy/requirements.txt
+++ b/gateway/obs-proxy/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn[standard]
+httpx
+slowapi
+pydantic-settings
+python-json-logger

--- a/gateway/obs-proxy/requirements.txt
+++ b/gateway/obs-proxy/requirements.txt
@@ -4,3 +4,7 @@ httpx
 slowapi
 pydantic-settings
 python-json-logger
+
+pytest
+pytest-asyncio
+respx

--- a/gateway/obs-proxy/security.py
+++ b/gateway/obs-proxy/security.py
@@ -1,0 +1,21 @@
+from fastapi import HTTPException, Request, status
+
+from .config import get_settings
+
+
+async def require_api_key(request: Request) -> None:
+    settings = get_settings()
+    if settings.OBS_API_KEY:
+        api_key = request.headers.get("X-Obs-Api-Key")
+        if api_key != settings.OBS_API_KEY:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API Key"
+            )
+
+
+def client_ip(request: Request) -> str:
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    client = request.client
+    return client.host if client else "unknown"

--- a/gateway/obs-proxy/tests/test_app.py
+++ b/gateway/obs-proxy/tests/test_app.py
@@ -1,0 +1,75 @@
+import os
+import sys
+import types
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+
+# Setup fake package for obs_proxy because directory name has hyphen
+BASE_DIR = Path(__file__).resolve().parents[1]
+pkg = types.ModuleType("obs_proxy")
+pkg.__path__ = [str(BASE_DIR)]
+sys.modules["obs_proxy"] = pkg
+
+# Configure environment before importing settings/app
+os.environ.update(
+    {
+        "PROM_BASE_URL": "http://prom",
+        "LOKI_BASE_URL": "http://loki",
+        "OBS_API_KEY": "secret",
+        "RETRIES": "1",
+        "TIMEOUT_SECONDS": "0.1",
+    }
+)
+
+from obs_proxy.config import get_settings  # type: ignore
+get_settings.cache_clear()
+from obs_proxy.app import app  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_healthz():
+    async with httpx.AsyncClient(app=app, base_url="http://test") as ac:
+        resp = await ac.get("/healthz")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_prom_query_success():
+    respx.get("http://prom/api/v1/query").mock(
+        return_value=httpx.Response(200, json={"data": 1})
+    )
+    async with httpx.AsyncClient(app=app, base_url="http://test") as ac:
+        resp = await ac.get(
+            "/obs/prom/query",
+            params={"query": "up"},
+            headers={"X-Obs-Api-Key": "secret"},
+        )
+    assert resp.status_code == 200
+    assert resp.json() == {"data": 1}
+
+
+@pytest.mark.asyncio
+async def test_auth_required():
+    async with httpx.AsyncClient(app=app, base_url="http://test") as ac:
+        resp = await ac.get("/obs/prom/query", params={"query": "up"})
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_loki_query_failure_returns_502():
+    respx.get("http://loki/loki/api/v1/query").mock(side_effect=httpx.TimeoutException("timeout"))
+    async with httpx.AsyncClient(app=app, base_url="http://test") as ac:
+        resp = await ac.get(
+            "/obs/loki/query",
+            params={"query": "{}"},
+            headers={"X-Obs-Api-Key": "secret"},
+        )
+    assert resp.status_code == 502
+    body = resp.json()
+    assert body["upstream"] == "loki"

--- a/infra/compose.obs-proxy.yml
+++ b/infra/compose.obs-proxy.yml
@@ -1,0 +1,25 @@
+version: "3.8"
+services:
+  obs-proxy:
+    build:
+      context: ./gateway/obs-proxy
+    image: chessapp/obs-proxy:dev
+    container_name: obs-proxy
+    environment:
+      - PROM_BASE_URL=${PROM_BASE_URL:-http://prometheus:9090}
+      - LOKI_BASE_URL=${LOKI_BASE_URL:-http://loki:3100}
+      - OBS_API_KEY=${OBS_API_KEY:-}
+      - CORS_ALLOW_ORIGINS=${CORS_ALLOW_ORIGINS:-http://localhost:5173}
+      - RATE_LIMIT=${RATE_LIMIT:-60/minute}
+      - TIMEOUT_SECONDS=${TIMEOUT_SECONDS:-3.0}
+      - RETRIES=${RETRIES:-2}
+    ports:
+      - "8088:8088"
+    restart: unless-stopped
+    networks:
+      - default
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8088/healthz"]
+      interval: 10s
+      timeout: 3s
+      retries: 5

--- a/infra/grafana/dashboards/obs/evaluation.json
+++ b/infra/grafana/dashboards/obs/evaluation.json
@@ -1,0 +1,40 @@
+{
+  "uid": "obs-eval-v1",
+  "title": "ChessApp – Evaluation (v1)",
+  "schemaVersion": 39,
+  "version": 1,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Eval Top-1",
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "chs_eval_top1_accuracy" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Eval Top-3",
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "chs_eval_top3_accuracy" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Blunder Rate (/100 moves)",
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "chs_eval_blunders_per_100" }
+      ]
+    },
+    {
+      "type": "logs",
+      "title": "Logs",
+      "datasource": "Loki",
+      "targets": [
+        { "expr": "{component=\"evaluation\"} |= \"report\"" }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/dashboards/obs/system-health.json
+++ b/infra/grafana/dashboards/obs/system-health.json
@@ -1,0 +1,58 @@
+{
+  "uid": "obs-system-v1",
+  "title": "ChessApp – System Health (v1)",
+  "schemaVersion": 39,
+  "version": 1,
+  "templating": {
+    "list": [
+      {
+        "name": "job",
+        "type": "query",
+        "datasource": "Prometheus",
+        "query": "label_values(up, job)",
+        "refresh": 1
+      },
+      {
+        "name": "instance",
+        "type": "query",
+        "datasource": "Prometheus",
+        "query": "label_values(up, instance)",
+        "refresh": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Targets Up by Job",
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "sum by (job) (up)" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Scrape Duration (p95)",
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "histogram_quantile(0.95, sum by (job,le) (rate(scrape_duration_seconds_bucket[5m])))" }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Prometheus TSDB Series",
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "prometheus_tsdb_head_series" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Loki Log Volume (last 1h)",
+      "datasource": "Loki",
+      "targets": [
+        { "expr": "sum(rate({app=~\".+\"}[5m])) by (app)" }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/dashboards/obs/training-selfplay.json
+++ b/infra/grafana/dashboards/obs/training-selfplay.json
@@ -1,0 +1,40 @@
+{
+  "uid": "obs-train-v1",
+  "title": "ChessApp – Training & Self-Play (v1)",
+  "schemaVersion": 39,
+  "version": 1,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Training Loss",
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "chs_training_loss" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Samples/sec",
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "chs_training_throughput_samples_per_sec" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Self-Play Games/min",
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "chs_selfplay_games_per_min" }
+      ]
+    },
+    {
+      "type": "logs",
+      "title": "Training Errors",
+      "datasource": "Loki",
+      "targets": [
+        { "expr": "{component=\"training\"} |= \"ERROR\"" }
+      ]
+    }
+  ]
+}

--- a/scripts/smoke_obs_proxy.sh
+++ b/scripts/smoke_obs_proxy.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+BASE=${1:-http://localhost:8088}
+KEY_HEADER=${OBS_KEY:+-H "X-Obs-Api-Key: ${OBS_KEY}"}
+
+echo "Health:"
+curl -sf ${BASE}/healthz | jq .
+
+echo "Prom up:"
+curl -sf ${KEY_HEADER} "${BASE}/obs/prom/query?query=up" | jq '.status'
+
+echo "Loki labels (may be empty):"
+curl -sf ${KEY_HEADER} "${BASE}/obs/loki/query?query={}" | jq '.status'

--- a/tests/obs_proxy/conftest.py
+++ b/tests/obs_proxy/conftest.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import types
+from pathlib import Path
+
+import httpx
+import pytest
+
+BASE_DIR = Path(__file__).resolve().parents[2] / "gateway" / "obs-proxy"
+pkg = types.ModuleType("obs_proxy")
+pkg.__path__ = [str(BASE_DIR)]
+sys.modules.setdefault("obs_proxy", pkg)
+
+os.environ.setdefault("PROM_BASE_URL", "http://prom.example")
+os.environ.setdefault("LOKI_BASE_URL", "http://loki.example")
+os.environ.setdefault("OBS_API_KEY", "secret")
+os.environ.setdefault("CORS_ALLOW_ORIGINS", "http://localhost:5173")
+os.environ.setdefault("RATE_LIMIT", "5/minute")
+os.environ.setdefault("RETRIES", "1")
+os.environ.setdefault("TIMEOUT_SECONDS", "0.01")
+
+from obs_proxy.config import get_settings  # type: ignore
+get_settings.cache_clear()
+from obs_proxy.app import app  # type: ignore
+
+
+@pytest.fixture
+async def client() -> httpx.AsyncClient:
+    async with httpx.AsyncClient(app=app, base_url="http://test") as ac:
+        yield ac

--- a/tests/obs_proxy/test_loki_query.py
+++ b/tests/obs_proxy/test_loki_query.py
@@ -1,0 +1,84 @@
+import httpx
+import pytest
+import respx
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_loki_query_success(client):
+    route = respx.get("http://loki.example/loki/api/v1/query").mock(
+        return_value=httpx.Response(200, json={"data": {"result": []}})
+    )
+    resp = await client.get(
+        "/obs/loki/query", params={"query": "{}"}, headers={"X-Obs-Api-Key": "secret"}
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"data": {"result": []}}
+    assert route.call_count == 1
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_loki_query_4xx(client):
+    route = respx.get("http://loki.example/loki/api/v1/query").mock(
+        return_value=httpx.Response(400, json={"error": "bad"})
+    )
+    resp = await client.get(
+        "/obs/loki/query", params={"query": "{}"}, headers={"X-Obs-Api-Key": "secret"}
+    )
+    assert resp.status_code == 400
+    assert resp.json() == {"error": "bad"}
+    assert route.call_count == 1
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_loki_query_retry(client):
+    route = respx.get("http://loki.example/loki/api/v1/query").mock(
+        side_effect=[
+            httpx.Response(500),
+            httpx.Response(200, json={"data": {"result": []}}),
+        ]
+    )
+    resp = await client.get(
+        "/obs/loki/query", params={"query": "{}"}, headers={"X-Obs-Api-Key": "secret"}
+    )
+    assert resp.status_code == 200
+    assert route.call_count == 2
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_loki_query_timeout(client):
+    route = respx.get("http://loki.example/loki/api/v1/query").mock(
+        side_effect=httpx.TimeoutException("timeout")
+    )
+    resp = await client.get(
+        "/obs/loki/query", params={"query": "{}"}, headers={"X-Obs-Api-Key": "secret"}
+    )
+    assert resp.status_code == 502
+    body = resp.json()
+    assert body["upstream"] == "loki"
+    assert route.call_count == 2
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_loki_query_rate_limit(client):
+    from obs_proxy.app import app as obs_app  # type: ignore
+
+    obs_app.state.limiter.storage.clear()  # reset before test
+    route = respx.get("http://loki.example/loki/api/v1/query").mock(
+        return_value=httpx.Response(200, json={"data": {"result": []}})
+    )
+    for _ in range(5):
+        ok = await client.get(
+            "/obs/loki/query", params={"query": "{}"}, headers={"X-Obs-Api-Key": "secret"}
+        )
+        assert ok.status_code == 200
+    resp = await client.get(
+        "/obs/loki/query", params={"query": "{}"}, headers={"X-Obs-Api-Key": "secret"}
+    )
+    assert resp.status_code == 429
+    assert route.call_count == 5
+    obs_app.state.limiter.storage.clear()

--- a/tests/obs_proxy/test_prom_range.py
+++ b/tests/obs_proxy/test_prom_range.py
@@ -1,0 +1,94 @@
+import httpx
+import pytest
+import respx
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_prom_range_success(client):
+    route = respx.get("http://prom.example/api/v1/query_range").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "status": "success",
+                "data": {"resultType": "matrix", "result": []},
+            },
+        )
+    )
+    resp = await client.get(
+        "/obs/prom/range",
+        params={"query": "up", "start": "0", "end": "10", "step": "1"},
+        headers={"X-Obs-Api-Key": "secret"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "status": "success",
+        "data": {"resultType": "matrix", "result": []},
+    }
+    assert route.call_count == 1
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_prom_range_4xx(client):
+    route = respx.get("http://prom.example/api/v1/query_range").mock(
+        return_value=httpx.Response(400, json={"error": "bad"})
+    )
+    resp = await client.get(
+        "/obs/prom/range",
+        params={"query": "up", "start": "0", "end": "10", "step": "1"},
+        headers={"X-Obs-Api-Key": "secret"},
+    )
+    assert resp.status_code == 400
+    assert resp.json() == {"error": "bad"}
+    assert route.call_count == 1
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_prom_range_retry(client):
+    route = respx.get("http://prom.example/api/v1/query_range").mock(
+        side_effect=[
+            httpx.Response(500),
+            httpx.Response(
+                200,
+                json={
+                    "status": "success",
+                    "data": {"resultType": "matrix", "result": []},
+                },
+            ),
+        ]
+    )
+    resp = await client.get(
+        "/obs/prom/range",
+        params={"query": "up", "start": "0", "end": "10", "step": "1"},
+        headers={"X-Obs-Api-Key": "secret"},
+    )
+    assert resp.status_code == 200
+    assert route.call_count == 2
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_prom_range_timeout(client):
+    route = respx.get("http://prom.example/api/v1/query_range").mock(
+        side_effect=httpx.TimeoutException("timeout")
+    )
+    resp = await client.get(
+        "/obs/prom/range",
+        params={"query": "up", "start": "0", "end": "10", "step": "1"},
+        headers={"X-Obs-Api-Key": "secret"},
+    )
+    assert resp.status_code == 502
+    body = resp.json()
+    assert body["upstream"] == "prom"
+    assert route.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_prom_range_missing_api_key(client):
+    resp = await client.get(
+        "/obs/prom/range",
+        params={"query": "up", "start": "0", "end": "10", "step": "1"},
+    )
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- add obs proxy FastAPI service with Prometheus and Loki forwarding
- include async clients with retry/backoff and API key enforcement
- provide tests for proxy routes and error handling

## Testing
- `pytest gateway/obs-proxy/tests/test_app.py -q` *(fails: ModuleNotFoundError: No module named 'respx')*

------
https://chatgpt.com/codex/tasks/task_e_68b6f203483c832bb12563fcf10a6329