### PR TITLE
Add self-play runner and offline eval scaffolding

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.swp
+*.log
+.env
+venv/
+.venv/
+build/
+dist/
+*.egg-info/

--- a/.github/workflows/selfplay_eval.yml
+++ b/.github/workflows/selfplay_eval.yml
@@ -1,0 +1,38 @@
+name: selfplay-eval
+
+on:
+  push:
+    paths:
+      - 'ml/selfplay-runner/**'
+      - 'ml/eval-offline/**'
+      - 'tests/selfplay/**'
+      - 'tests/eval/**'
+      - 'scripts/**'
+      - '.github/workflows/selfplay_eval.yml'
+  pull_request:
+    paths:
+      - 'ml/selfplay-runner/**'
+      - 'ml/eval-offline/**'
+      - 'tests/selfplay/**'
+      - 'tests/eval/**'
+      - 'scripts/**'
+      - '.github/workflows/selfplay_eval.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: |
+          pip install fastapi httpx tenacity python-chess prometheus_client pydantic \
+            python-json-logger uvicorn[standard] pandas matplotlib numpy mlflow pyarrow torch pytest
+      - name: Run tests
+        run: pytest tests/selfplay tests/eval -q
+      - name: Smoke eval
+        run: bash scripts/eval_smoke.sh
+      - name: Smoke selfplay
+        run: bash scripts/selfplay_smoke.sh

--- a/.github/workflows/selfplay_eval.yml
+++ b/.github/workflows/selfplay_eval.yml
@@ -2,24 +2,12 @@ name: selfplay-eval
 
 on:
   push:
-    paths:
-      - 'ml/selfplay-runner/**'
-      - 'ml/eval-offline/**'
-      - 'tests/selfplay/**'
-      - 'tests/eval/**'
-      - 'scripts/**'
-      - '.github/workflows/selfplay_eval.yml'
+    branches: [development]
   pull_request:
-    paths:
-      - 'ml/selfplay-runner/**'
-      - 'ml/eval-offline/**'
-      - 'tests/selfplay/**'
-      - 'tests/eval/**'
-      - 'scripts/**'
-      - '.github/workflows/selfplay_eval.yml'
+    branches: [development]
 
 jobs:
-  test:
+  build-runner:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -30,9 +18,57 @@ jobs:
         run: |
           pip install fastapi httpx tenacity python-chess prometheus_client pydantic \
             python-json-logger uvicorn[standard] pandas matplotlib numpy mlflow pyarrow torch pytest
-      - name: Run tests
-        run: pytest tests/selfplay tests/eval -q
-      - name: Smoke eval
-        run: bash scripts/eval_smoke.sh
+      - name: Lint
+        run: python -m py_compile ml/selfplay-runner/app/*.py
+      - name: Tests
+        run: pytest tests/selfplay -q
+
+  build-eval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: |
+          pip install fastapi httpx tenacity python-chess prometheus_client pydantic \
+            python-json-logger uvicorn[standard] pandas matplotlib numpy mlflow pyarrow torch pytest
+      - name: Tests
+        run: pytest tests/eval -q
+
+  smoke:
+    needs: [build-runner, build-eval]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: |
+          pip install fastapi httpx tenacity python-chess prometheus_client pydantic \
+            python-json-logger uvicorn[standard] pandas matplotlib numpy mlflow pyarrow torch pytest
+      - name: Start services
+        run: make -f Makefile.selfplay up
       - name: Smoke selfplay
         run: bash scripts/selfplay_smoke.sh
+      - name: Smoke eval
+        run: bash scripts/eval_smoke.sh
+      - name: Upload selfplay artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: selfplay-artifacts
+          path: artifacts/selfplay
+          if-no-files-found: ignore
+      - name: Upload eval artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-artifacts
+          path: artifacts/eval
+          if-no-files-found: ignore
+      - name: Stop services
+        if: always()
+        run: make -f Makefile.selfplay down

--- a/Makefile.selfplay
+++ b/Makefile.selfplay
@@ -1,0 +1,19 @@
+COMPOSE=infra/compose.selfplay.yml
+
+up:
+	docker compose -f $(COMPOSE) up -d --build
+
+down:
+	docker compose -f $(COMPOSE) down -v
+
+logs:
+	docker compose -f $(COMPOSE) logs -f
+
+ps:
+	docker compose -f $(COMPOSE) ps
+
+curl:
+	curl -s localhost:8011/healthz && echo && curl -s localhost:8012/healthz || true
+
+rebuild:
+	docker compose -f $(COMPOSE) up -d --build --force-recreate

--- a/docs/selfplay_eval/ACCEPTANCE.md
+++ b/docs/selfplay_eval/ACCEPTANCE.md
@@ -1,0 +1,30 @@
+# Abnahmebericht Self-Play & Offline-Eval
+
+- Datum/Uhrzeit: <!-- YYYY-MM-DD HH:MM -->
+- Umgebung: <!-- z.B. local/docker -->
+
+## Runs
+- Self-Play Run-ID: <!-- UUID -->
+- Eval Run-ID: <!-- UUID -->
+
+## Screenshots
+Füge hier Screens der Grafana-Panels ein:
+- obs-selfplay-v1
+- obs-eval-v1
+
+## JSON-Logs
+Auszug mit MDC-Feldern (`ts`, `level`, `component`, `run_id`/`eval_id`).
+
+## Ergebnisse
+- Win-Rate: <!-- e.g. 0.55 -->
+- Elo: <!-- e.g. 20 -->
+- val_loss: <!-- -->
+- val_acc_top1: <!-- -->
+- ece: <!-- -->
+
+## Checkliste
+- [ ] Services laufen (`/healthz`)
+- [ ] Metriken verfügbar (`/metrics`)
+- [ ] Artefakte geschrieben
+- [ ] Dashboards importiert
+- [ ] CI grün

--- a/docs/selfplay_eval/API_SAMPLES.http
+++ b/docs/selfplay_eval/API_SAMPLES.http
@@ -1,0 +1,27 @@
+### Start Self-Play
+POST http://localhost:8011/runner/selfplay/start
+Content-Type: application/json
+
+{
+  "modelId": "candidate_foo",
+  "baselineId": "prod",
+  "games": 10,
+  "concurrency": 2,
+  "seed": 42
+}
+
+### Get Self-Play Status
+GET http://localhost:8011/runner/selfplay/runs/{{runId}}
+
+### Start Eval
+POST http://localhost:8012/runner/eval/start
+Content-Type: application/json
+
+{
+  "modelId": "candidate_foo",
+  "datasetId": "val_2025_08",
+  "metrics": ["val_loss","val_acc_top1","ece"]
+}
+
+### Get Eval Status
+GET http://localhost:8012/runner/eval/{{evalId}}

--- a/docs/selfplay_eval/PR_TEMPLATE.md
+++ b/docs/selfplay_eval/PR_TEMPLATE.md
@@ -1,0 +1,20 @@
+# Pipeline A — Self-Play & Offline-Eval (add-only)
+
+## Changelog (add-only)
+<!-- Liste der hinzugefügten Dateien/Pfade -->
+- ...
+
+## DoD erfüllt?
+- [ ] Ja (Belege anfügen)
+- [ ] Nein
+
+## Screens / Panel-Links / MLflow-Run-ID
+- Self-Play Dashboard: <!-- URL -->
+- Eval Dashboard: <!-- URL -->
+- MLflow Run: <!-- ID -->
+
+## Risiken & Follow-Ups
+- ...
+
+## Abnahme-Hinweise
+Siehe [ACCEPTANCE.md](ACCEPTANCE.md) für vollständige Logs und Screenshots.

--- a/docs/selfplay_eval/README.md
+++ b/docs/selfplay_eval/README.md
@@ -1,3 +1,17 @@
 # Self-Play & Offline Evaluation
 
-Coming in A6
+## Dashboards
+
+The repository provides example Grafana dashboards:
+
+- **Self-Play — v1** (UID: `obs-selfplay-v1`)
+- **Offline Eval — v1** (UID: `obs-eval-v1`)
+
+Import via Grafana → Dashboards → Import and upload the JSON from `infra/grafana/dashboards/obs/`.
+
+Example queries:
+
+```
+sum(rate(chs_selfplay_games_total[5m]))
+max(chs_eval_last_val_acc_top1)
+```

--- a/docs/selfplay_eval/README.md
+++ b/docs/selfplay_eval/README.md
@@ -1,0 +1,3 @@
+# Self-Play & Offline Evaluation
+
+Coming in A6

--- a/docs/selfplay_eval/README.md
+++ b/docs/selfplay_eval/README.md
@@ -1,17 +1,83 @@
 # Self-Play & Offline Evaluation
 
-## Dashboards
+## 1. Überblick
+Zwei interne Dienste unterstützen Entwicklungs- und Testprozesse:
 
-The repository provides example Grafana dashboards:
+- **Self-Play Runner** (Port 8011) orchestriert Matches zwischen Kandidaten- und Baseline-Modellen und schreibt Reports.
+- **Offline Eval** (Port 8012) bewertet Modelle gegen ein FEN/Label‑Dataset, erstellt Plots und logged Kennzahlen.
 
-- **Self-Play — v1** (UID: `obs-selfplay-v1`)
-- **Offline Eval — v1** (UID: `obs-eval-v1`)
-
-Import via Grafana → Dashboards → Import and upload the JSON from `infra/grafana/dashboards/obs/`.
-
-Example queries:
-
+## 2. Start / Stop
 ```
-sum(rate(chs_selfplay_games_total[5m]))
-max(chs_eval_last_val_acc_top1)
+make -f Makefile.selfplay up   # Services starten
+make -f Makefile.selfplay logs # Logs verfolgen
+make -f Makefile.selfplay down # Services stoppen
 ```
+
+## 3. Endpunkte
+### Self-Play Runner (8011)
+**POST /runner/selfplay/start**
+```json
+{"modelId":"candidate_foo","baselineId":"prod","games":20,"concurrency":4,"seed":42}
+```
+Antwort → `{"runId":"<uuid>"}`
+
+**GET /runner/selfplay/runs/{runId}**
+Antwort →
+```json
+{"runId":"<uuid>","status":"completed","progress":{"played":20,"total":20},"metrics":{"elo":12.3,"winRate":0.55},"reportUri":"/artifacts/selfplay/<uuid>/report.json"}
+```
+
+### Offline Eval (8012)
+**POST /runner/eval/start**
+```json
+{"modelId":"candidate_foo","datasetId":"val_2025_08","metrics":["val_loss","val_acc_top1","ece"]}
+```
+Antwort → `{"evalId":"<uuid>"}`
+
+**GET /runner/eval/{evalId}**
+Antwort →
+```json
+{"evalId":"<uuid>","status":"completed","metrics":{"val_loss":0.9,"val_acc_top1":0.71,"ece":0.08},"reportUri":"/artifacts/eval/<uuid>/report.json"}
+```
+
+## 4. Artefakt-Struktur
+```
+artifacts/
+  selfplay/<runId>/report.json  *.pgn
+  eval/<evalId>/report.json  metrics.json  calibration.png  topk.png  …
+```
+
+## 5. Prometheus-Metriken
+**Self-Play**
+- `chs_selfplay_games_total{result="win|loss|draw"}`
+- `chs_selfplay_elo_estimate`
+- `chs_selfplay_move_time_seconds_bucket`
+- `chs_selfplay_queue_depth`
+- `chs_selfplay_errors_total{type}`
+
+**Eval**
+- `chs_eval_last_val_loss`
+- `chs_eval_last_val_acc_top1`
+- `chs_eval_last_val_acc_top3`
+- `chs_eval_last_ece`
+- `chs_eval_runtime_seconds_bucket`
+- `chs_eval_errors_total{type}`
+
+## 6. Dashboards
+- Self-Play — v1 (UID `obs-selfplay-v1`)
+- Offline Eval — v1 (UID `obs-eval-v1`)
+
+Import über Grafana → Dashboards → Import → JSON aus `infra/grafana/dashboards/obs/`.
+
+## 7. Beispiel-Workflows
+- **20-Spiele-Smoke:** `bash scripts/selfplay_smoke.sh`
+- **Mini-Dataset-Eval:** `bash scripts/eval_smoke.sh`
+- **MLflow-Logging:** setze `MLFLOW_TRACKING_URI` und starte Evaluierung; Artefakte werden geloggt.
+
+## 8. Troubleshooting
+- `SERVE_PREDICT_URL` nicht erreichbar → Runner nutzt Dummy-Zug-Generator.
+- Timeouts/5xx vom Serve werden gezählt (`chs_selfplay_errors_total`).
+- Fehlende Modelle → Dummy-Policy.
+
+## 9. DoD & Abnahme
+Details und Prüfprotokolle stehen in [ACCEPTANCE.md](ACCEPTANCE.md).

--- a/infra/compose.selfplay.yml
+++ b/infra/compose.selfplay.yml
@@ -1,0 +1,25 @@
+networks:
+  chsapp_selfplay: {}
+
+services:
+  selfplay-runner:
+    build:
+      context: ../ml/selfplay-runner
+      dockerfile: Dockerfile
+    container_name: chs_selfplay_runner
+    environment:
+      SERVE_PREDICT_URL: ${SERVE_PREDICT_URL:-http://api:8080/v1/predict}
+    ports:
+      - "8011:8011"
+    networks: [chsapp_selfplay]
+
+  eval-offline:
+    build:
+      context: ../ml/eval-offline
+      dockerfile: Dockerfile
+    container_name: chs_eval_offline
+    environment:
+      MLFLOW_TRACKING_URI: ${MLFLOW_TRACKING_URI:-http://mlflow:5000}
+    ports:
+      - "8012:8012"
+    networks: [chsapp_selfplay]

--- a/infra/grafana/dashboards/obs/obs-eval-v1.json
+++ b/infra/grafana/dashboards/obs/obs-eval-v1.json
@@ -1,0 +1,67 @@
+{
+  "id": null,
+  "uid": "obs-eval-v1",
+  "title": "Offline Eval — v1",
+  "timezone": "",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {"from": "now-6h", "to": "now"},
+  "templating": {"list": []},
+  "panels": [
+    {
+      "id": 1,
+      "type": "gauge",
+      "title": "val_loss",
+      "targets": [
+        {"expr": "max(chs_eval_last_val_loss)", "refId": "A"}
+      ],
+      "gridPos": {"x": 0, "y": 0, "w": 8, "h": 8}
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "val_acc_top1",
+      "targets": [
+        {"expr": "max(chs_eval_last_val_acc_top1)", "refId": "A"}
+      ],
+      "gridPos": {"x": 8, "y": 0, "w": 8, "h": 8}
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "val_acc_top3",
+      "targets": [
+        {"expr": "max(chs_eval_last_val_acc_top3)", "refId": "A"}
+      ],
+      "gridPos": {"x": 16, "y": 0, "w": 8, "h": 8}
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "ece",
+      "targets": [
+        {"expr": "max(chs_eval_last_ece)", "refId": "A"}
+      ],
+      "gridPos": {"x": 0, "y": 8, "w": 8, "h": 8}
+    },
+    {
+      "id": 5,
+      "type": "heatmap",
+      "title": "Eval Duration",
+      "targets": [
+        {"expr": "rate(chs_eval_runtime_seconds_bucket[5m])", "refId": "A"}
+      ],
+      "gridPos": {"x": 8, "y": 8, "w": 8, "h": 8}
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Errors",
+      "targets": [
+        {"expr": "sum(increase(chs_eval_errors_total[6h])) by (type)", "refId": "A"}
+      ],
+      "gridPos": {"x": 16, "y": 8, "w": 8, "h": 8}
+    }
+  ]
+}

--- a/infra/grafana/dashboards/obs/obs-selfplay-v1.json
+++ b/infra/grafana/dashboards/obs/obs-selfplay-v1.json
@@ -1,0 +1,67 @@
+{
+  "id": null,
+  "uid": "obs-selfplay-v1",
+  "title": "Self-Play — v1",
+  "timezone": "",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {"from": "now-6h", "to": "now"},
+  "templating": {"list": []},
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Games/s",
+      "targets": [
+        {"expr": "sum(rate(chs_selfplay_games_total[5m]))", "refId": "A"}
+      ],
+      "gridPos": {"x": 0, "y": 0, "w": 12, "h": 8}
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Win-Rate %",
+      "targets": [
+        {"expr": "100 * (sum(increase(chs_selfplay_games_total{result=\"win\"}[1h])) / sum(increase(chs_selfplay_games_total[1h])))", "refId": "A"}
+      ],
+      "gridPos": {"x": 12, "y": 0, "w": 12, "h": 8}
+    },
+    {
+      "id": 3,
+      "type": "gauge",
+      "title": "Elo Estimate",
+      "targets": [
+        {"expr": "max(chs_selfplay_elo_estimate)", "refId": "A"}
+      ],
+      "gridPos": {"x": 0, "y": 8, "w": 6, "h": 8}
+    },
+    {
+      "id": 4,
+      "type": "gauge",
+      "title": "Queue Depth",
+      "targets": [
+        {"expr": "max(chs_selfplay_queue_depth)", "refId": "A"}
+      ],
+      "gridPos": {"x": 6, "y": 8, "w": 6, "h": 8}
+    },
+    {
+      "id": 5,
+      "type": "heatmap",
+      "title": "Move Time",
+      "targets": [
+        {"expr": "rate(chs_selfplay_move_time_seconds_bucket[5m])", "refId": "A"}
+      ],
+      "gridPos": {"x": 12, "y": 8, "w": 12, "h": 8}
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Errors",
+      "targets": [
+        {"expr": "sum(increase(chs_selfplay_errors_total[1h])) by (type)", "refId": "A"}
+      ],
+      "gridPos": {"x": 0, "y": 16, "w": 24, "h": 8}
+    }
+  ]
+}

--- a/ml/eval-offline/Dockerfile
+++ b/ml/eval-offline/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+
+RUN pip install --no-cache-dir uv
+COPY pyproject.toml .
+RUN uv pip install --system -r pyproject.toml
+
+COPY app ./app
+COPY eval.py ./eval.py
+
+RUN useradd -m appuser
+USER appuser
+
+ENV PORT=8012
+EXPOSE 8012
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8012"]

--- a/ml/eval-offline/app/__init__.py
+++ b/ml/eval-offline/app/__init__.py
@@ -1,0 +1,2 @@
+"""Offline evaluation service package."""
+

--- a/ml/eval-offline/app/evaluator.py
+++ b/ml/eval-offline/app/evaluator.py
@@ -1,0 +1,209 @@
+"""Offline evaluation core logic."""
+from __future__ import annotations
+
+import json
+import math
+import os
+import random
+import time
+import uuid
+from pathlib import Path
+from typing import Iterable, Tuple
+
+from .metrics import (
+    LAST_ECE,
+    LAST_VAL_ACC_TOP1,
+    LAST_VAL_LOSS,
+    RUNTIME_SECONDS,
+    ERRORS_TOTAL,
+)
+
+try:  # optional dependencies
+    import pandas as pd
+except Exception:  # pragma: no cover - handled gracefully
+    pd = None
+try:
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover
+    plt = None
+try:
+    import mlflow
+except Exception:  # pragma: no cover
+    mlflow = None
+
+MOVES = [
+    "a2a3",
+    "a2a4",
+    "b2b3",
+    "b2b4",
+    "c2c3",
+    "c2c4",
+    "d2d3",
+    "d2d4",
+    "e2e3",
+    "e2e4",
+]
+
+
+class DummyModel:
+    """Fallback model producing uniform random moves."""
+
+    def predict_proba(self, fen: str) -> dict[str, float]:  # pragma: no cover - simple
+        p = 1.0 / len(MOVES)
+        return {m: p for m in MOVES}
+
+
+def load_dataset(path: str | None, limit: int) -> list[Tuple[str, str]]:
+    """Load dataset from Parquet or generate dummy data."""
+    data: list[Tuple[str, str]] = []
+    if path and pd is not None:
+        try:
+            df = pd.read_parquet(path)
+            fens: Iterable[str] = df["fen"].tolist()
+            labels: Iterable[str] = df["label_uci"].tolist()
+            data = list(zip(fens, labels))[:limit]
+        except Exception:
+            data = []
+    if not data:
+        random.seed(0)
+        start_fen = "rn1qkbnr/pppbpppp/8/3p4/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 3"
+        for _ in range(limit):
+            data.append((start_fen, random.choice(MOVES)))
+    return data
+
+
+def load_model(model_id: str) -> DummyModel:
+    """Load torch model if available otherwise return DummyModel."""
+    try:  # pragma: no cover - optional
+        import torch
+    except Exception:  # pragma: no cover - torch missing
+        return DummyModel()
+    path = Path("artifacts/models") / model_id / "best.pt"
+    if path.exists():
+        try:
+            model = torch.load(path, map_location="cpu")
+            model.eval()
+            return model  # type: ignore[return-value]
+        except Exception:
+            ERRORS_TOTAL.labels(type="model_load").inc()
+    return DummyModel()
+
+
+def run_evaluation(
+    *,
+    model_id: str,
+    dataset: str | None,
+    metrics: list[str] | None,
+    batch_size: int,
+    limit: int,
+    seed: int,
+    outdir: str | None,
+    eval_id: str | None = None,
+) -> tuple[dict[str, float], str]:
+    """Execute evaluation and return metrics and outdir."""
+    random.seed(seed)
+    eval_id = eval_id or uuid.uuid4().hex
+    start = time.time()
+
+    data = load_dataset(dataset, limit)
+    model = load_model(model_id)
+
+    total_loss = 0.0
+    top1 = 0
+    top3 = 0
+    bin_totals = [0] * 10
+    bin_correct = [0] * 10
+
+    for fen, label in data:
+        probs = getattr(model, "predict_proba", DummyModel().predict_proba)(fen)
+        p_true = probs.get(label, 1e-12)
+        total_loss -= math.log(p_true)
+        ordered = sorted(probs.items(), key=lambda kv: kv[1], reverse=True)
+        predictions = [m for m, _ in ordered]
+        if predictions and predictions[0] == label:
+            top1 += 1
+        if label in predictions[:3]:
+            top3 += 1
+        p_max = ordered[0][1] if ordered else 1.0
+        idx = min(int(p_max * 10), 9)
+        bin_totals[idx] += 1
+        if predictions and predictions[0] == label:
+            bin_correct[idx] += 1
+
+    n = max(len(data), 1)
+    val_loss = total_loss / n
+    val_acc_top1 = top1 / n
+    val_acc_top3 = top3 / n
+
+    ece = 0.0
+    for i in range(10):
+        if bin_totals[i]:
+            acc = bin_correct[i] / bin_totals[i]
+            conf = (i + 0.5) / 10
+            ece += abs(acc - conf) * bin_totals[i] / n
+
+    metrics_dict = {
+        "val_loss": val_loss,
+        "val_acc_top1": val_acc_top1,
+        "val_acc_top3": val_acc_top3,
+        "ece": ece,
+    }
+
+    out_path = Path(outdir or f"artifacts/eval/{eval_id}")
+    out_path.mkdir(parents=True, exist_ok=True)
+    (out_path / "metrics.json").write_text(json.dumps(metrics_dict, indent=2))
+    report = {
+        "evalId": eval_id,
+        "modelId": model_id,
+        "dataset": dataset,
+        "startedAt": start,
+        "finishedAt": time.time(),
+        "metrics": metrics_dict,
+    }
+    (out_path / "report.json").write_text(json.dumps(report, indent=2))
+
+    if plt is not None:
+        try:
+            fig, ax = plt.subplots()
+            confs = [(i + 0.5) / 10 for i in range(10)]
+            accs = [bin_correct[i] / bin_totals[i] if bin_totals[i] else 0 for i in range(10)]
+            ax.plot(confs, accs, marker="o")
+            ax.plot([0, 1], [0, 1], linestyle="--")
+            ax.set_xlabel("Confidence")
+            ax.set_ylabel("Accuracy")
+            fig.savefig(out_path / "calibration.png")
+            plt.close(fig)
+
+            fig, ax = plt.subplots()
+            ax.bar(["top1", "top3"], [val_acc_top1, val_acc_top3])
+            fig.savefig(out_path / "topk.png")
+            plt.close(fig)
+        except Exception:
+            (out_path / "calibration.png").write_text("plot error")
+            (out_path / "topk.png").write_text("plot error")
+    else:  # pragma: no cover - env without matplotlib
+        (out_path / "calibration.png").write_text("plot unavailable")
+        (out_path / "topk.png").write_text("plot unavailable")
+
+    if mlflow is not None and os.getenv("MLFLOW_TRACKING_URI"):
+        try:  # pragma: no cover - external service
+            with mlflow.start_run(run_name=f"offline-eval:{eval_id}"):
+                mlflow.log_params(
+                    {
+                        "model_id": model_id,
+                        "dataset": dataset,
+                        "batch_size": batch_size,
+                        "limit": limit,
+                    }
+                )
+                mlflow.log_metrics(metrics_dict)
+                mlflow.log_artifacts(str(out_path))
+        except Exception:
+            ERRORS_TOTAL.labels(type="mlflow").inc()
+
+    runtime = time.time() - start
+    RUNTIME_SECONDS.observe(runtime)
+    LAST_VAL_ACC_TOP1.set(val_acc_top1)
+    LAST_VAL_LOSS.set(val_loss)
+    LAST_ECE.set(ece)
+    return metrics_dict, str(out_path)

--- a/ml/eval-offline/app/main.py
+++ b/ml/eval-offline/app/main.py
@@ -1,7 +1,20 @@
 import logging
-from fastapi import FastAPI, Response
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Dict
+
+from fastapi import FastAPI, Response, HTTPException
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
-from pythonjsonlogger import jsonlogger
+
+try:  # optional logging dependency
+    from pythonjsonlogger import jsonlogger
+except Exception:  # pragma: no cover
+    jsonlogger = None
+
+from .evaluator import run_evaluation
+from .metrics import ERRORS_TOTAL
+from .schemas import EvalStartRequest, EvalStatus
 
 
 class ContextFilter(logging.Filter):
@@ -23,16 +36,23 @@ class ContextFilter(logging.Filter):
 
 def setup_logging(component: str) -> None:
     handler = logging.StreamHandler()
-    formatter = jsonlogger.JsonFormatter(
-        "%(asctime)s %(levelname)s %(message)s %(component)s %(run_id)s %(eval_id)s",
-        rename_fields={"asctime": "ts", "levelname": "level", "message": "msg"},
-    )
+    if jsonlogger is not None:
+        formatter = jsonlogger.JsonFormatter(
+            "%(asctime)s %(levelname)s %(message)s %(component)s %(run_id)s %(eval_id)s",
+            rename_fields={"asctime": "ts", "levelname": "level", "message": "msg"},
+        )
+    else:
+        formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
     handler.setFormatter(formatter)
     root = logging.getLogger()
     root.handlers.clear()
     root.addHandler(handler)
     root.addFilter(ContextFilter(component))
     root.setLevel(logging.INFO)
+
+
+runs: Dict[str, EvalStatus] = {}
+executor = ThreadPoolExecutor(max_workers=1)
 
 
 def create_app() -> FastAPI:
@@ -46,6 +66,43 @@ def create_app() -> FastAPI:
     @app.get("/metrics")
     def metrics() -> Response:  # pragma: no cover - simple
         return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+    @app.post("/runner/eval/start")
+    def start(req: EvalStartRequest) -> dict[str, str]:
+        eval_id = uuid.uuid4().hex
+        runs[eval_id] = EvalStatus(eval_id=eval_id, status="running")
+
+        def _run() -> None:
+            try:
+                metrics, outdir = run_evaluation(
+                    model_id=req.model_id,
+                    dataset=req.dataset_id,
+                    metrics=req.metrics,
+                    batch_size=req.batch_size,
+                    limit=req.limit,
+                    seed=req.seed,
+                    outdir=None,
+                    eval_id=eval_id,
+                )
+                runs[eval_id] = EvalStatus(
+                    eval_id=eval_id,
+                    status="completed",
+                    metrics=metrics,
+                    report_uri=str(Path(outdir) / "report.json"),
+                )
+            except Exception:
+                ERRORS_TOTAL.labels(type="other").inc()
+                runs[eval_id] = EvalStatus(eval_id=eval_id, status="error")
+
+        executor.submit(_run)
+        return {"evalId": eval_id}
+
+    @app.get("/runner/eval/{eval_id}", response_model=EvalStatus)
+    def status(eval_id: str) -> EvalStatus:
+        state = runs.get(eval_id)
+        if state is None:
+            raise HTTPException(status_code=404, detail="unknown evalId")
+        return state
 
     return app
 

--- a/ml/eval-offline/app/main.py
+++ b/ml/eval-offline/app/main.py
@@ -1,0 +1,53 @@
+import logging
+from fastapi import FastAPI, Response
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+from pythonjsonlogger import jsonlogger
+
+
+class ContextFilter(logging.Filter):
+    """Adds default logging fields."""
+
+    def __init__(self, component: str):
+        super().__init__()
+        self.component = component
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - simple
+        if not hasattr(record, "component"):
+            record.component = self.component
+        if not hasattr(record, "run_id"):
+            record.run_id = None
+        if not hasattr(record, "eval_id"):
+            record.eval_id = None
+        return True
+
+
+def setup_logging(component: str) -> None:
+    handler = logging.StreamHandler()
+    formatter = jsonlogger.JsonFormatter(
+        "%(asctime)s %(levelname)s %(message)s %(component)s %(run_id)s %(eval_id)s",
+        rename_fields={"asctime": "ts", "levelname": "level", "message": "msg"},
+    )
+    handler.setFormatter(formatter)
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.addHandler(handler)
+    root.addFilter(ContextFilter(component))
+    root.setLevel(logging.INFO)
+
+
+def create_app() -> FastAPI:
+    setup_logging("eval-offline")
+    app = FastAPI()
+
+    @app.get("/healthz")
+    def healthz() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/metrics")
+    def metrics() -> Response:  # pragma: no cover - simple
+        return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+    return app
+
+
+app = create_app()

--- a/ml/eval-offline/app/metrics.py
+++ b/ml/eval-offline/app/metrics.py
@@ -1,0 +1,38 @@
+"""Prometheus metrics for offline evaluation."""
+try:
+    from prometheus_client import Counter, Gauge, Histogram
+except Exception:  # pragma: no cover - optional dependency
+    class _Noop:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def labels(self, *args, **kwargs):  # noqa: D401 - noop
+            return self
+
+        def inc(self, *args, **kwargs) -> None:  # noqa: D401 - noop
+            return None
+
+        def set(self, *args, **kwargs) -> None:  # noqa: D401 - noop
+            return None
+
+        def observe(self, *args, **kwargs) -> None:  # noqa: D401 - noop
+            return None
+
+    Counter = Gauge = Histogram = _Noop
+
+LAST_VAL_ACC_TOP1 = Gauge(
+    "chs_eval_last_val_acc_top1", "Last evaluated top-1 accuracy"
+)
+LAST_VAL_LOSS = Gauge(
+    "chs_eval_last_val_loss", "Last evaluated validation loss"
+)
+LAST_ECE = Gauge(
+    "chs_eval_last_ece", "Last evaluated expected calibration error"
+)
+RUNTIME_SECONDS = Histogram(
+    "chs_eval_runtime_seconds", "Evaluation runtime in seconds",
+    buckets=[1, 2, 5, 10, 20, 50, 100]
+)
+ERRORS_TOTAL = Counter(
+    "chs_eval_errors_total", "Total evaluation errors", ["type"]
+)

--- a/ml/eval-offline/app/schemas.py
+++ b/ml/eval-offline/app/schemas.py
@@ -1,0 +1,25 @@
+"""Pydantic models for evaluation service."""
+from pydantic import BaseModel, Field
+from typing import Dict, Optional
+
+
+class EvalStartRequest(BaseModel):
+    model_id: str = Field(alias="modelId")
+    dataset_id: Optional[str] = Field(default=None, alias="datasetId")
+    metrics: Optional[list[str]] = None
+    batch_size: int = Field(default=32, alias="batchSize")
+    limit: int = 200
+    seed: int = 0
+
+    class Config:
+        populate_by_name = True
+
+
+class EvalStatus(BaseModel):
+    eval_id: str = Field(alias="evalId")
+    status: str
+    metrics: Dict[str, float] | None = None
+    report_uri: str | None = Field(default=None, alias="reportUri")
+
+    class Config:
+        populate_by_name = True

--- a/ml/eval-offline/eval.py
+++ b/ml/eval-offline/eval.py
@@ -1,10 +1,62 @@
 import argparse
+import logging
+import uuid
+
+try:
+    from pythonjsonlogger import jsonlogger
+except Exception:  # pragma: no cover - optional dependency
+    jsonlogger = None
+
+from app.evaluator import run_evaluation
+
+
+def setup_logging() -> None:
+    handler = logging.StreamHandler()
+    if jsonlogger is not None:
+        formatter = jsonlogger.JsonFormatter(
+            "%(asctime)s %(levelname)s %(message)s %(component)s %(eval_id)s",
+            rename_fields={"asctime": "ts", "levelname": "level", "message": "msg"},
+        )
+    else:
+        formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+    handler.setFormatter(formatter)
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.addHandler(handler)
+    root.setLevel(logging.INFO)
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Offline evaluation CLI (placeholder)")
-    parser.parse_args()
-    return 0
+    parser = argparse.ArgumentParser(description="Offline evaluation CLI")
+    parser.add_argument("--model-id", required=True)
+    parser.add_argument("--dataset", required=False)
+    parser.add_argument("--metrics", nargs="*", default=None)
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--limit", type=int, default=200)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--outdir", default=None)
+    args = parser.parse_args()
+
+    setup_logging()
+    eval_id = uuid.uuid4().hex
+    outdir = args.outdir or f"artifacts/eval/{eval_id}"
+    logging.info("start", extra={"component": "eval-offline", "eval_id": eval_id})
+    try:
+        run_evaluation(
+            model_id=args.model_id,
+            dataset=args.dataset,
+            metrics=args.metrics,
+            batch_size=args.batch_size,
+            limit=args.limit,
+            seed=args.seed,
+            outdir=outdir,
+            eval_id=eval_id,
+        )
+        logging.info("completed", extra={"component": "eval-offline", "eval_id": eval_id})
+        return 0
+    except Exception:  # pragma: no cover - defensive
+        logging.exception("evaluation failed", extra={"component": "eval-offline", "eval_id": eval_id})
+        return 1
 
 
 if __name__ == "__main__":

--- a/ml/eval-offline/eval.py
+++ b/ml/eval-offline/eval.py
@@ -1,0 +1,11 @@
+import argparse
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Offline evaluation CLI (placeholder)")
+    parser.parse_args()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ml/eval-offline/pyproject.toml
+++ b/ml/eval-offline/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "eval-offline"
+version = "0.1.0"
+description = "Offline evaluation service"
+authors = [{name = "ChessApp Team"}]
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi",
+    "uvicorn[standard]",
+    "prometheus_client",
+    "pydantic",
+    "mlflow",
+    "pandas",
+    "pyarrow",
+    "matplotlib",
+    "numpy",
+]
+
+[project.optional-dependencies]
+torch = ["torch"]
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"

--- a/ml/selfplay-runner/Dockerfile
+++ b/ml/selfplay-runner/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+
+RUN pip install --no-cache-dir uv
+COPY pyproject.toml .
+RUN uv pip install --system -r pyproject.toml
+
+COPY app ./app
+
+RUN useradd -m appuser
+USER appuser
+
+ENV PORT=8011
+EXPOSE 8011
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8011"]

--- a/ml/selfplay-runner/app/__init__.py
+++ b/ml/selfplay-runner/app/__init__.py
@@ -1,0 +1,3 @@
+from .main import create_app, app
+
+__all__ = ["create_app", "app"]

--- a/ml/selfplay-runner/app/elo.py
+++ b/ml/selfplay-runner/app/elo.py
@@ -1,0 +1,12 @@
+"""Helpers for Elo calculations."""
+from __future__ import annotations
+
+import math
+
+
+def win_rate_to_elo(p: float) -> float:
+    """Convert win-rate (0<p<1) to Elo difference with clamping."""
+    if p <= 0 or p >= 1:
+        return 0.0
+    elo = -400 * math.log10(1 / p - 1)
+    return max(min(elo, 800.0), -800.0)

--- a/ml/selfplay-runner/app/main.py
+++ b/ml/selfplay-runner/app/main.py
@@ -1,0 +1,53 @@
+import logging
+from fastapi import FastAPI, Response
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+from pythonjsonlogger import jsonlogger
+
+
+class ContextFilter(logging.Filter):
+    """Adds default logging fields."""
+
+    def __init__(self, component: str):
+        super().__init__()
+        self.component = component
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - simple
+        if not hasattr(record, "component"):
+            record.component = self.component
+        if not hasattr(record, "run_id"):
+            record.run_id = None
+        if not hasattr(record, "eval_id"):
+            record.eval_id = None
+        return True
+
+
+def setup_logging(component: str) -> None:
+    handler = logging.StreamHandler()
+    formatter = jsonlogger.JsonFormatter(
+        "%(asctime)s %(levelname)s %(message)s %(component)s %(run_id)s %(eval_id)s",
+        rename_fields={"asctime": "ts", "levelname": "level", "message": "msg"},
+    )
+    handler.setFormatter(formatter)
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.addHandler(handler)
+    root.addFilter(ContextFilter(component))
+    root.setLevel(logging.INFO)
+
+
+def create_app() -> FastAPI:
+    setup_logging("selfplay-runner")
+    app = FastAPI()
+
+    @app.get("/healthz")
+    def healthz() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/metrics")
+    def metrics() -> Response:  # pragma: no cover - simple
+        return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+    return app
+
+
+app = create_app()

--- a/ml/selfplay-runner/app/main.py
+++ b/ml/selfplay-runner/app/main.py
@@ -1,7 +1,12 @@
 import logging
-from fastapi import FastAPI, Response
+import asyncio
+from fastapi import FastAPI, Response, HTTPException
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 from pythonjsonlogger import jsonlogger
+
+from .runner import SelfPlayRunner
+from .schemas import RunStatus, StartRequest
+from .serve_client import ServeClient
 
 
 class ContextFilter(logging.Filter):
@@ -39,6 +44,9 @@ def create_app() -> FastAPI:
     setup_logging("selfplay-runner")
     app = FastAPI()
 
+    client = ServeClient()
+    runner = SelfPlayRunner(client)
+
     @app.get("/healthz")
     def healthz() -> dict[str, str]:
         return {"status": "ok"}
@@ -46,6 +54,23 @@ def create_app() -> FastAPI:
     @app.get("/metrics")
     def metrics() -> Response:  # pragma: no cover - simple
         return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+    @app.post("/runner/selfplay/start")
+    def start(req: StartRequest) -> dict[str, str]:
+        run_id = runner.start(req)
+        return {"runId": run_id}
+
+    @app.get("/runner/selfplay/runs/{run_id}", response_model=RunStatus)
+    def status(run_id: str) -> RunStatus:
+        st = runner.get_status(run_id)
+        if not st:
+            raise HTTPException(status_code=404, detail="run not found")
+        return st
+
+    @app.get("/runner/selfplay/debug")
+    async def debug(games: int = 4) -> RunStatus:
+        run_status = await asyncio.to_thread(runner.run_debug, games)
+        return run_status
 
     return app
 

--- a/ml/selfplay-runner/app/metrics.py
+++ b/ml/selfplay-runner/app/metrics.py
@@ -1,0 +1,31 @@
+"""Prometheus metrics for the self-play runner."""
+from prometheus_client import Counter, Gauge, Histogram
+
+# Counter for game results
+games_total = Counter(
+     "chs_selfplay_games_total",
+     "Number of self-play games played",
+     labelnames=["result"],
+ )
+
+# Gauge for current Elo estimate
+elo_estimate = Gauge(
+    "chs_selfplay_elo_estimate", "Estimated Elo difference between models"
+)
+
+# Histogram for move time
+move_time_seconds = Histogram(
+    "chs_selfplay_move_time_seconds",
+    "Time spent generating a move",
+    buckets=[0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2],
+)
+
+# Gauge for queue depth
+queue_depth = Gauge(
+    "chs_selfplay_queue_depth", "Number of outstanding games in the queue"
+)
+
+# Counter for errors
+errors_total = Counter(
+    "chs_selfplay_errors_total", "Errors when calling serve", labelnames=["type"]
+)

--- a/ml/selfplay-runner/app/runner.py
+++ b/ml/selfplay-runner/app/runner.py
@@ -1,0 +1,152 @@
+"""Self-play run orchestration."""
+from __future__ import annotations
+
+import random
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, List
+from uuid import uuid4
+
+import chess
+
+from . import metrics, storage, elo
+from .schemas import RunStatus, StartRequest
+from .serve_client import ServeClient
+
+
+@dataclass
+class RunInfo:
+    request: StartRequest
+    status: str = "running"
+    progress: Dict[str, int] = field(default_factory=lambda: {"played": 0, "total": 0})
+    metrics: Dict[str, float | None] = field(
+        default_factory=lambda: {"elo": None, "winRate": None}
+    )
+    results: List[dict] = field(default_factory=list)
+    started_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+    finished_at: str | None = None
+    report_uri: str | None = None
+
+
+class SelfPlayRunner:
+    """Coordinates self-play runs."""
+
+    def __init__(self, client: ServeClient) -> None:
+        self.client = client
+        self.runs: Dict[str, RunInfo] = {}
+        self._lock = threading.Lock()
+
+    def start(self, request: StartRequest) -> str:
+        run_id = uuid4().hex
+        info = RunInfo(request=request)
+        info.progress["total"] = request.games
+        with self._lock:
+            self.runs[run_id] = info
+        threading.Thread(target=self._run, args=(run_id,), daemon=True).start()
+        return run_id
+
+    def get_status(self, run_id: str) -> RunStatus | None:
+        with self._lock:
+            info = self.runs.get(run_id)
+        if not info:
+            return None
+        return RunStatus(
+            runId=run_id,
+            status=info.status,
+            progress=info.progress,
+            metrics=info.metrics,
+            reportUri=info.report_uri,
+        )
+
+    # internal
+    def _run(self, run_id: str) -> None:
+        info = self.runs[run_id]
+        req = info.request
+        wins = losses = draws = 0
+        random.seed(req.seed)
+        metrics.queue_depth.set(req.games)
+
+        def play_game(game_idx: int) -> None:
+            nonlocal wins, losses, draws
+            board = chess.Board()
+            white_model = req.modelId if game_idx % 2 == 0 else req.baselineId
+            black_model = req.baselineId if game_idx % 2 == 0 else req.modelId
+            while not board.is_game_over():
+                model = white_model if board.turn == chess.WHITE else black_model
+                fen = board.fen()
+                start_t = time.perf_counter()
+                try:
+                    move_str = self.client.predict(fen, model)
+                    move = chess.Move.from_uci(move_str)
+                    if move not in board.legal_moves:
+                        raise ValueError("illegal move")
+                except Exception:
+                    move = random.choice(list(board.legal_moves))
+                duration = time.perf_counter() - start_t
+                metrics.move_time_seconds.observe(duration)
+                board.push(move)
+            result = board.result()
+            if result == "1-0":
+                if white_model == req.modelId:
+                    wins += 1
+                    res = "win"
+                else:
+                    losses += 1
+                    res = "loss"
+            elif result == "0-1":
+                if black_model == req.modelId:
+                    wins += 1
+                    res = "win"
+                else:
+                    losses += 1
+                    res = "loss"
+            else:
+                draws += 1
+                res = "draw"
+            metrics.games_total.labels(result=res).inc()
+            info.results.append(
+                {"gameIdx": game_idx, "result": res, "plyCount": board.ply()}
+            )
+            info.progress["played"] += 1
+            metrics.queue_depth.set(req.games - info.progress["played"])
+
+        with ThreadPoolExecutor(max_workers=req.concurrency) as ex:
+            futures = [ex.submit(play_game, i) for i in range(req.games)]
+            for _ in as_completed(futures):
+                pass
+
+        info.finished_at = datetime.utcnow().isoformat()
+        wins_s = wins + 0.5
+        losses_s = losses + 0.5
+        p = (wins_s + 0.5 * draws) / (wins_s + losses_s + draws)
+        info.metrics["winRate"] = p
+        elo_val = elo.win_rate_to_elo(p)
+        info.metrics["elo"] = elo_val
+        metrics.elo_estimate.set(elo_val)
+        report = {
+            "runId": run_id,
+            "request": req.model_dump(),
+            "startedAt": info.started_at,
+            "finishedAt": info.finished_at,
+            "results": info.results,
+            "summary": {"winRate": p, "elo": elo_val},
+        }
+        info.report_uri = storage.save_report(run_id, report)
+        info.status = "completed"
+        metrics.queue_depth.set(0)
+
+    # for debug endpoint
+    def run_debug(self, games: int) -> RunStatus:
+        req = StartRequest(
+            modelId="debug", baselineId="debug", games=games, concurrency=1, seed=42
+        )
+        run_id = self.start(req)
+        # poll until done
+        while True:
+            status = self.get_status(run_id)
+            if status and status.status == "completed":
+                return status
+            time.sleep(0.1)

--- a/ml/selfplay-runner/app/schemas.py
+++ b/ml/selfplay-runner/app/schemas.py
@@ -1,0 +1,34 @@
+"""Pydantic schemas for the self-play runner service."""
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+from typing import Optional
+
+
+class StartRequest(BaseModel):
+    """Request payload to start a self-play run."""
+
+    modelId: str
+    baselineId: str
+    games: int = Field(gt=0)
+    concurrency: int = Field(gt=0)
+    seed: int = 0
+
+
+class RunStatus(BaseModel):
+    """Status information about a running/completed self-play run."""
+
+    runId: str
+    status: str
+    progress: dict[str, int]
+    metrics: dict[str, Optional[float]]
+    reportUri: Optional[str] = None
+
+
+class MetricPayload(BaseModel):
+    """Internal metric payload for tracking move statistics and errors."""
+
+    runId: str
+    result: Optional[str] = None
+    error_type: Optional[str] = None
+    move_time: Optional[float] = None

--- a/ml/selfplay-runner/app/serve_client.py
+++ b/ml/selfplay-runner/app/serve_client.py
@@ -1,0 +1,45 @@
+"""HTTP client for communicating with the model serving API."""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+from . import metrics
+
+DEFAULT_URL = "http://localhost:8009/v1/predict"
+
+
+class ServeClient:
+    """Client for the external model serve API."""
+
+    def __init__(self, url: str | None = None) -> None:
+        self.url = url or os.getenv("SERVE_PREDICT_URL", DEFAULT_URL)
+        self._client = httpx.Client(timeout=3.0)
+
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=0.1))
+    def _post(self, payload: dict[str, Any]) -> httpx.Response:
+        return self._client.post(self.url, json=payload)
+
+    def predict(self, fen: str, model_id: str) -> str:
+        """Request a move from the model serve endpoint."""
+
+        try:
+            resp = self._post({"fen": fen, "modelId": model_id})
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("move", "")
+        except httpx.TimeoutException:
+            metrics.errors_total.labels(type="serve_timeout").inc()
+            raise
+        except httpx.HTTPStatusError as exc:  # pragma: no cover - simple
+            if 500 <= exc.response.status_code < 600:
+                metrics.errors_total.labels(type="serve_5xx").inc()
+            else:
+                metrics.errors_total.labels(type="other").inc()
+            raise
+        except Exception:  # pragma: no cover - simple
+            metrics.errors_total.labels(type="other").inc()
+            raise

--- a/ml/selfplay-runner/app/storage.py
+++ b/ml/selfplay-runner/app/storage.py
@@ -1,0 +1,18 @@
+"""Utilities for persisting self-play artifacts."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+BASE_DIR = Path("artifacts/selfplay")
+
+
+def save_report(run_id: str, report: dict[str, Any]) -> str:
+    """Persist the report for a run and return its path."""
+    run_dir = BASE_DIR / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    path = run_dir / "report.json"
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(report, fh)
+    return str(path)

--- a/ml/selfplay-runner/pyproject.toml
+++ b/ml/selfplay-runner/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "selfplay-runner"
+version = "0.1.0"
+description = "Self-play runner service"
+authors = [{name = "ChessApp Team"}]
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi",
+    "uvicorn[standard]",
+    "prometheus_client",
+    "pydantic",
+    "httpx",
+    "tenacity",
+    "python-json-logger",
+]
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"

--- a/ml/selfplay-runner/pyproject.toml
+++ b/ml/selfplay-runner/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "httpx",
     "tenacity",
     "python-json-logger",
+    "python-chess",
 ]
 
 [build-system]

--- a/scripts/eval_smoke.sh
+++ b/scripts/eval_smoke.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python ml/eval-offline/eval.py --model-id dummy --limit 5 >/dev/null

--- a/scripts/eval_smoke.sh
+++ b/scripts/eval_smoke.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -euo pipefail
-python ml/eval-offline/eval.py --model-id dummy --limit 5 >/dev/null
+python -m ml.eval-offline.eval --model-id candidate_foo --dataset /tmp/mini.parquet --limit 100

--- a/scripts/selfplay_smoke.sh
+++ b/scripts/selfplay_smoke.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+curl -s localhost:8011/healthz >/dev/null
+curl -s localhost:8011/runner/selfplay/debug?games=4 >/dev/null

--- a/scripts/selfplay_smoke.sh
+++ b/scripts/selfplay_smoke.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
-curl -s localhost:8011/healthz >/dev/null
-curl -s localhost:8011/runner/selfplay/debug?games=4 >/dev/null
+curl -s -X POST localhost:8011/runner/selfplay/start -H 'content-type: application/json' \
+  -d '{"modelId":"candidate_foo","baselineId":"prod","games":10,"concurrency":2,"seed":42}' | tee /tmp/run.json
+RUN=$(jq -r .runId /tmp/run.json)
+for i in {1..60}; do
+  curl -s localhost:8011/runner/selfplay/runs/$RUN | jq .status
+  sleep 2
+done

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+import sys
+import types
+from pathlib import Path
+import importlib.machinery
+
+# ensure ml directory on path
+root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root / 'ml'))
+
+# expose selfplay_runner package alias for hyphenated directory
+spr_root = root / 'ml' / 'selfplay-runner'
+pkg = types.ModuleType('selfplay_runner')
+loader_spec = importlib.machinery.ModuleSpec('selfplay_runner', loader=None, is_package=True)
+loader_spec.submodule_search_locations = [str(spr_root)]
+pkg.__spec__ = loader_spec
+pkg.__path__ = [str(spr_root)]
+sys.modules.setdefault('selfplay_runner', pkg)
+
+# minimal tenacity stub with retry support
+class stop_after_attempt:
+    def __init__(self, attempts: int):
+        self.attempts = attempts
+
+class wait_exponential:
+    def __init__(self, **kwargs):
+        pass
+
+def retry(stop=None, wait=None):
+    def decorator(fn):
+        def wrapper(*args, **kwargs):
+            max_attempts = getattr(stop, 'attempts', 1)
+            attempt = 0
+            while True:
+                try:
+                    return fn(*args, **kwargs)
+                except Exception:
+                    attempt += 1
+                    if attempt >= max_attempts:
+                        raise
+        return wrapper
+    return decorator
+
+tn = types.ModuleType('tenacity')
+tn.retry = retry
+tn.stop_after_attempt = stop_after_attempt
+tn.wait_exponential = wait_exponential
+sys.modules.setdefault('tenacity', tn)

--- a/tests/eval/test_eval_overfit.py
+++ b/tests/eval/test_eval_overfit.py
@@ -1,0 +1,36 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+
+def test_eval_overfit(tmp_path: Path):
+    start_fen = "rn1qkbnr/pppbpppp/8/3p4/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 3"
+    labels = ["a2a3"] * 35 + ["e2e4"] * 15
+    df = pd.DataFrame({"fen": [start_fen] * 50, "label_uci": labels})
+    dataset = tmp_path / "data.parquet"
+    df.to_parquet(dataset)
+
+    outdir = tmp_path / "out"
+    cmd = [
+        sys.executable,
+        "ml/eval-offline/eval.py",
+        "--model-id",
+        "dummy",
+        "--dataset",
+        str(dataset),
+        "--batch-size",
+        "8",
+        "--limit",
+        "50",
+        "--outdir",
+        str(outdir),
+    ]
+    subprocess.run(cmd, check=True)
+
+    metrics = json.loads((outdir / "metrics.json").read_text())
+    assert metrics["val_acc_top1"] >= 0.65
+    assert (outdir / "calibration.png").exists()
+    assert (outdir / "topk.png").exists()

--- a/tests/selfplay/test_resilience_retry.py
+++ b/tests/selfplay/test_resilience_retry.py
@@ -1,0 +1,62 @@
+import time
+from fastapi.testclient import TestClient
+import httpx
+
+from selfplay_runner.app.main import create_app
+from selfplay_runner.app.runner import SelfPlayRunner
+from selfplay_runner.app.serve_client import ServeClient
+from selfplay_runner.app.metrics import errors_total
+from selfplay_runner.app import storage, elo
+
+
+def test_resilience_retry(monkeypatch):
+    # patch ServeClient.predict to timeout twice then succeed
+    calls = {"n": 0}
+
+    def fake_predict(self, fen: str, model_id: str) -> str:
+        if calls["n"] < 2:
+            calls["n"] += 1
+            errors_total.labels(type="serve_timeout").inc()
+            raise httpx.TimeoutException("boom")
+        return "e2e4"
+
+    monkeypatch.setattr(ServeClient, "predict", fake_predict)
+
+    # patch runner to call predict and finish
+    def fake_run(self, run_id: str) -> None:
+        info = self.runs[run_id]
+        # retry until success
+        while True:
+            try:
+                self.client.predict("fake", info.request.modelId)
+                break
+            except httpx.TimeoutException:
+                continue
+        info.results.append({"gameIdx": 0, "result": "win", "plyCount": 1})
+        info.progress["played"] = 1
+        info.metrics["winRate"] = 1.0
+        info.metrics["elo"] = elo.win_rate_to_elo(1.0)
+        report = {
+            "runId": run_id,
+            "request": info.request.model_dump(),
+            "startedAt": info.started_at,
+            "finishedAt": info.started_at,
+            "results": info.results,
+            "summary": {"winRate": 1.0, "elo": info.metrics["elo"]},
+        }
+        info.report_uri = storage.save_report(run_id, report)
+        info.status = "completed"
+
+    monkeypatch.setattr(SelfPlayRunner, "_run", fake_run)
+
+    app = create_app()
+    client = TestClient(app)
+    resp = client.post(
+        "/runner/selfplay/start",
+        json={"modelId": "cand", "baselineId": "base", "games": 1, "concurrency": 1, "seed": 0},
+    )
+    run_id = resp.json()["runId"]
+    time.sleep(0.1)
+    st = client.get(f"/runner/selfplay/runs/{run_id}").json()
+    assert st["status"] == "completed"
+    assert errors_total.labels(type="serve_timeout")._value.get() >= 2

--- a/tests/selfplay/test_runner_smoke.py
+++ b/tests/selfplay/test_runner_smoke.py
@@ -1,0 +1,56 @@
+import json
+import time
+from datetime import datetime
+from fastapi.testclient import TestClient
+
+from selfplay_runner.app.main import create_app
+from selfplay_runner.app.runner import SelfPlayRunner
+from selfplay_runner.app import storage, elo
+
+
+def test_runner_smoke(monkeypatch):
+    # patch run to produce deterministic 60% win rate and create report
+    def fake_run(self, run_id: str) -> None:
+        info = self.runs[run_id]
+        games = info.request.games
+        wins = int(games * 0.6)
+        for i in range(games):
+            res = "win" if i < wins else "loss"
+            info.results.append({"gameIdx": i, "result": res, "plyCount": 1})
+            info.progress["played"] += 1
+        p = wins / games
+        info.metrics["winRate"] = p
+        info.metrics["elo"] = elo.win_rate_to_elo(p)
+        report = {
+            "runId": run_id,
+            "request": info.request.model_dump(),
+            "startedAt": info.started_at,
+            "finishedAt": datetime.utcnow().isoformat(),
+            "results": info.results,
+            "summary": {"winRate": p, "elo": info.metrics["elo"]},
+        }
+        info.report_uri = storage.save_report(run_id, report)
+        info.status = "completed"
+
+    monkeypatch.setattr(SelfPlayRunner, "_run", fake_run)
+
+    app = create_app()
+    client = TestClient(app)
+    resp = client.post(
+        "/runner/selfplay/start",
+        json={"modelId": "cand", "baselineId": "base", "games": 10, "concurrency": 2, "seed": 0},
+    )
+    run_id = resp.json()["runId"]
+
+    # poll until completed
+    while True:
+        st = client.get(f"/runner/selfplay/runs/{run_id}").json()
+        if st["status"] == "completed":
+            break
+        time.sleep(0.1)
+
+    assert 0.5 <= st["metrics"]["winRate"] <= 0.8
+    assert st["metrics"]["elo"] > 0
+    report_path = st["reportUri"]
+    data = json.loads(open(report_path).read())
+    assert data["summary"]["winRate"] == st["metrics"]["winRate"]


### PR DESCRIPTION
## Summary
- scaffold FastAPI services for self-play runner and offline evaluation with /healthz and /metrics
- add CLI placeholder for offline evaluation
- add compose stack, Makefile, Dockerfiles, and docs for running self-play/eval services

## Testing
- `make -f Makefile.selfplay up` *(fails: docker: No such file or directory)*
- `make -f Makefile.selfplay curl` *(no response; services not running)*

------
https://chatgpt.com/codex/tasks/task_e_68b72581dddc832bb702b6a650bef214