### PR TITLE
fix: install project deps from pyproject in Docker builds

### DIFF
--- a/ml/eval-offline/Dockerfile
+++ b/ml/eval-offline/Dockerfile
@@ -5,9 +5,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
 
 RUN pip install --no-cache-dir uv
 COPY pyproject.toml .
-RUN uv pip install --system -r pyproject.toml
-
 COPY app ./app
+RUN uv pip install --system -e .
 COPY eval.py ./eval.py
 
 RUN useradd -m appuser

--- a/ml/selfplay-runner/Dockerfile
+++ b/ml/selfplay-runner/Dockerfile
@@ -5,9 +5,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
 
 RUN pip install --no-cache-dir uv
 COPY pyproject.toml .
-RUN uv pip install --system -r pyproject.toml
-
 COPY app ./app
+RUN uv pip install --system -e .
 
 RUN useradd -m appuser
 USER appuser


### PR DESCRIPTION
## Summary
- install selfplay-runner package with `uv pip install --system -e .`
- build offline-eval image with project in editable mode

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'config')*
- `make -f Makefile.selfplay up` *(fails: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b7365a6d2c832b9d2124638ce0aca8