### PR TITLE
Refine security tests and populate game tags

### DIFF
--- a/api/api-app/src/test/java/com/chessapp/api/GamesControllerTest.java
+++ b/api/api-app/src/test/java/com/chessapp/api/GamesControllerTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.Instant;
+import java.util.Map;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
@@ -59,6 +60,7 @@ class GamesControllerTest extends com.chessapp.api.testutil.AbstractIntegrationT
         g.setBlackRating(1500);
         g.setPlatform(Platform.CHESS_COM);
         g.setPgn("[Event \"?\"]\n\n1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 1/2-1/2");
+        g.setTags(Map.of());
         gameRepository.save(g);
 
         Position p1 = new Position();

--- a/api/api-app/src/test/java/com/chessapp/api/it/SecurityIT.java
+++ b/api/api-app/src/test/java/com/chessapp/api/it/SecurityIT.java
@@ -66,14 +66,16 @@ class SecurityIT {
 
         String userToken = JwtTestUtils.signHmac256(secret, Map.of(
                 "sub", "user1",
-                "roles", List.of("USER")), Duration.ofMinutes(5));
+                "roles", List.of("USER"),
+                "scope", "api.read"), Duration.ofMinutes(5));
         mockMvc.perform(get("/actuator/prometheus")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + userToken))
                 .andExpect(status().isForbidden());
 
         String monitoringToken = JwtTestUtils.signHmac256(secret, Map.of(
                 "sub", "mon",
-                "roles", List.of("MONITORING")), Duration.ofMinutes(5));
+                "roles", List.of("MONITORING"),
+                "scope", "monitoring"), Duration.ofMinutes(5));
         mockMvc.perform(get("/actuator/prometheus")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + monitoringToken))
                 .andExpect(status().isOk())

--- a/api/api-app/src/test/java/com/chessapp/api/security/SecurityContractTest.java
+++ b/api/api-app/src/test/java/com/chessapp/api/security/SecurityContractTest.java
@@ -71,13 +71,16 @@ class SecurityContractTest {
         var encoder = new NimbusJwtEncoder(new com.nimbusds.jose.jwk.source.ImmutableSecret<>(raw));
         var now = Instant.now();
 
+        Instant expiresAt = now.plusSeconds(ttlSeconds);
+        Instant issuedAt = ttlSeconds < 0 ? expiresAt.minusSeconds(1) : now;
+
         var claims = JwtClaimsSet.builder()
                 .subject("dev-user")
                 .issuer("chessapp-dev")
                 .audience(List.of("api"))
                 .claim("scope", scope)
-                .issuedAt(now)
-                .expiresAt(now.plusSeconds(ttlSeconds))
+                .issuedAt(issuedAt)
+                .expiresAt(expiresAt)
                 .build();
 
         var headers = JwsHeader.with(MacAlgorithm.HS256).build();
@@ -88,7 +91,7 @@ class SecurityContractTest {
         return token(scope, 3600, "0123456789abcdef0123456789abcdef");
     }
     private String badSig(String scope) {
-        return token(scope, 3600, "WRONG-SECRET-123");
+        return token(scope, 3600, "ffffffffffffffffffffffffffffffff");
     }
     private String expired(String scope) {
         return token(scope, -60, "0123456789abcdef0123456789abcdef");


### PR DESCRIPTION
## Summary
- ensure SecurityContractTest uses sufficiently long secret when generating invalid JWT signatures
- allow negative TTL values when generating test tokens by adjusting issuedAt and expiresAt
- include explicit scopes in security integration tests to align with filter-chain expectations
- populate game tags in GamesControllerTest to satisfy not-null database constraint

## Testing
- `mvn -q -pl api-app -am -Dtest=com.chessapp.api.GamesControllerTest test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b87b902258832b9b2bf882f59bced2