### PR TITLE
docs: document frontend modules and setup

### DIFF
--- a/docs/frontend/baseframe.md
+++ b/docs/frontend/baseframe.md
@@ -1,0 +1,7 @@
+# BaseFrame (AppShell)
+Enthält Top-AppBar, Side-Nav (Rail/Expand), globalen Snackbar-Host und <RouterView/>.
+- AppBar: Brand, Theme-Toggle, Help, Overflow.
+- Side-Nav: Overview · Data · Datasets · Training · Models · Evaluation · Play · Observability.
+- Right-Drawer (optional): Logs/Details/Filter.
+Responsives 12-Spalten-Grid im Content.
+Observability-Slot pro Seite (Panel/Logs/Trace-Link).

--- a/docs/frontend/configuration.md
+++ b/docs/frontend/configuration.md
@@ -1,0 +1,13 @@
+# Configuration Workbench (KI/Workflow)
+**Route:** /config · Tabs:
+1) **Model Setup** – Presets & Hyperparameter (lr, batchSize, epochs, temperature, topk)  
+   - POST /v1/config/model (planned)
+2) **Dataset Selection** – Auswahl mehrerer Datasets + Split-Editor  
+   - POST /v1/config/datasets (planned)
+3) **Workflow** – Builder (Steps: Ingest→Build→Train→Eval→Promote)  
+   - POST /v1/workflows (planned), GET /v1/workflows/{id}
+4) **Self-Play** – games, timeControl, concurrency  
+   - POST /v1/selfplay (planned), GET /v1/selfplay/{runId}
+5) **Export/Snapshot** – Zustands-Export (Datasets/Models/Reports)  
+   - POST /v1/export/state (planned) → reportUri
+**Hinweis:** Buttons disabled, wenn Endpunkte (noch) fehlen. Keine /v1-Breakings.

--- a/docs/frontend/dev-setup.md
+++ b/docs/frontend/dev-setup.md
@@ -1,0 +1,9 @@
+# Dev-Setup (npm)
+- Node 20+, npm 10+
+- `.env.development`:
+  VITE_API_BASE=http://localhost:8080
+  VITE_OBS_BASE=http://localhost:3000
+  VITE_DEV_STATIC_TOKEN=dev-abc123
+- Start: `npm ci && npm run dev` (Vite, Hot Reload)
+- Vite-Proxy (vite.config.ts):
+  server: { proxy: { "/v1": VITE_API_BASE, "/actuator": VITE_API_BASE } }

--- a/docs/frontend/docker.md
+++ b/docs/frontend/docker.md
@@ -1,0 +1,7 @@
+# Docker/Compose (Prod & Dev)
+**Prod:** Multi-Stage Build (Node 20-alpine → nginx:alpine)
+- `frontend/Dockerfile` (build → /usr/share/nginx/html)
+- `frontend/nginx.conf` (SPA-Fallback auf /index.html)
+**Dev (optional):** `frontend/Dockerfile.dev` (Vite in Container, Bind-Mount)
+**Compose-Erweiterung:** infra/docker-compose.yml → Service `frontend` (Prod) + `fe-dev` (Dev)
+Ports: 5173 (dev), 8081 (prod nginx). ENV: API_BASE via `VITE_API_BASE`.

--- a/docs/frontend/login.md
+++ b/docs/frontend/login.md
@@ -1,0 +1,7 @@
+# Login (Auth)
+**Route:** /login  
+**Felder:** username, password, rememberMe  
+**Prod-Flow:** POST /v1/auth/login → {accessToken, ...}; Token via Axios-Interceptor (Authorization: Bearer).  
+**Dev-Fallback:** VITE_DEV_STATIC_TOKEN (Login akzeptiert Dummy-Creds).  
+**Guards:** Alle Routen außer /login geschützt.  
+**Fehler:** 401/403 → Snackbar + "View Logs".


### PR DESCRIPTION
## Summary
- add BaseFrame overview
- document login flow and route guarding
- describe configuration workbench tabs and planned endpoints
- note dev environment setup
- cover Docker builds and compose services

## Testing
- `npx markdownlint-cli2 docs/frontend/baseframe.md docs/frontend/login.md docs/frontend/configuration.md docs/frontend/dev-setup.md docs/frontend/docker.md` (fails: 403 Forbidden - GET https://registry.npmjs.org/markdownlint-cli2)
- `for f in docs/frontend/baseframe.md docs/frontend/login.md docs/frontend/configuration.md docs/frontend/dev-setup.md docs/frontend/docker.md; do npx markdown-link-check -q -c .markdownlinkcheck.json "$f" || true; done` (fails: 403 Forbidden - GET https://registry.npmjs.org/markdown-link-check)
- `pytest -q` (fails: ModuleNotFoundError: No module named 'config')

------
https://chatgpt.com/codex/tasks/task_e_68b8a512e128832bad1c779803385e8e