### PR TITLE
Add frontend Docker configs and ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+frontend/node_modules
+frontend/dist
+*.local.env
+coverage/
+cypress/screenshots
+cypress/videos
+
 # Build outputs
 **/target/
 **/out/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 8081
+HEALTHCHECK CMD wget -qO- http://localhost:8081/ >/dev/null || exit 1

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+EXPOSE 5173
+CMD ["npm","run","dev","--","--host","0.0.0.0"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,12 @@
+server {
+  listen 8081;
+  server_name _;
+  root /usr/share/nginx/html;
+  index index.html;
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+  location /v1 {
+    proxy_pass http://api:8080;
+  }
+}

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -272,3 +272,27 @@ services:
       - "8080:8080"
     networks: [ chs_net ]
     restart: unless-stopped
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    environment:
+      - VITE_API_BASE=http://api:8080
+    ports:
+      - "8081:8081"
+    depends_on:
+      - api
+
+  fe-dev:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.dev
+    environment:
+      - VITE_API_BASE=http://localhost:8080
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+    ports:
+      - "5173:5173"
+


### PR DESCRIPTION
## Summary
- ignore frontend build artifacts, local envs, coverage, and cypress outputs
- add production and dev Dockerfiles plus nginx for frontend
- wire frontend and fe-dev services into docker compose

## Testing
- ⚠️ `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_68b8a5702ea0832b9bfef5584626e2af