### PR TITLE
Add host header in frontend nginx config

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,7 +5,6 @@ COPY package*.json ./
 RUN npm ci
 COPY . .
 RUN npm run build
-
 FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -8,5 +8,6 @@ server {
   }
   location /v1 {
     proxy_pass http://api:8080;
+    proxy_set_header Host $host;
   }
 }


### PR DESCRIPTION
## Summary
- ensure nginx forwards Host header to backend
- tidy frontend Dockerfile stage separation

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'config', ModuleNotFoundError: No module named 'ml')*

------
https://chatgpt.com/codex/tasks/task_e_68b8b1e19008832ba8a8706a97496e16