### PR TITLE
chore: add docs lint and link checks

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,5 @@
+{
+  "default": true,
+  "MD013": false, // line length off for tables
+  "MD033": false  // inline HTML allowed
+}

--- a/Makefile.docs
+++ b/Makefile.docs
@@ -1,4 +1,4 @@
-.PHONY: docs fmt lint links ssot api-metrics
+.PHONY: docs fmt lint links ssot api-metrics docs-frontend
 
 docs: fmt lint links ssot
 
@@ -18,3 +18,8 @@ ssot:
 api-metrics:
 	python3 scripts/extract_endpoints.py > docs/API_ENDPOINTS.auto.md || true
 	python3 scripts/extract_metrics.py > docs/METRICS.auto.md || true
+
+.PHONY: docs-frontend
+docs-frontend:
+	npx markdownlint-cli2 "docs/**/*.md"
+	npx markdown-link-check -q -c scripts/linkcheck.config.json docs/frontend/*.md

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,8 @@
     "eslint-plugin-vue": "~10.3.0",
     "jiti": "^2.4.2",
     "jsdom": "^26.1.0",
+    "markdown-link-check": "^3.11.2",
+    "markdownlint-cli2": "^0.15.0",
     "npm-run-all2": "^8.0.4",
     "prettier": "3.6.2",
     "start-server-and-test": "^2.0.12",

--- a/scripts/linkcheck.config.json
+++ b/scripts/linkcheck.config.json
@@ -1,0 +1,6 @@
+{
+  "ignorePatterns": [
+    { "pattern": "^http://localhost" }
+  ],
+  "replacementPatterns": []
+}


### PR DESCRIPTION
## Summary
- add markdown lint and link check tools for frontend docs
- configure docs Makefile target and linkcheck ignore rules

## Testing
- `make -f Makefile.docs docs-frontend` *(fails: 403 Forbidden - GET https://registry.npmjs.org/markdownlint-cli2)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b1ed57f0832b9497f47a7b1d5712