### PR TITLE
feat(frontend): expand config workbench tabs

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,4 @@
+VITE_API_BASE=http://localhost:8080
+VITE_OBS_BASE=http://localhost:3000
+# Wenn true, werden Config-/Workflow-/Selfplay-POST Buttons aktiv
+VITE_ENABLE_CONFIG_ENDPOINTS=false

--- a/frontend/src/composables/usePlanned.ts
+++ b/frontend/src/composables/usePlanned.ts
@@ -1,0 +1,4 @@
+export function usePlanned() {
+  const enabled = import.meta.env.VITE_ENABLE_CONFIG_ENDPOINTS === 'true'
+  return { plannedEnabled: enabled }
+}

--- a/frontend/src/pages/ConfigWorkbench.vue
+++ b/frontend/src/pages/ConfigWorkbench.vue
@@ -8,18 +8,25 @@
       <v-tab value="export">Export</v-tab>
     </v-tabs>
     <v-window v-model="tab">
-      <v-window-item value="model"><v-alert type="info">Planned: POST /v1/config/model</v-alert></v-window-item>
-      <v-window-item value="datasets"><v-alert type="info">Planned: POST /v1/config/datasets</v-alert></v-window-item>
-      <v-window-item value="workflow"><v-alert type="info">Planned: POST /v1/workflows</v-alert></v-window-item>
-      <v-window-item value="selfplay"><v-alert type="info">Planned: POST /v1/selfplay</v-alert></v-window-item>
-      <v-window-item value="export"><v-alert type="info">Planned: POST /v1/export/state</v-alert></v-window-item>
+      <v-window-item value="model"><ModelSetupTab/></v-window-item>
+      <v-window-item value="datasets"><DatasetSelectionTab/></v-window-item>
+      <v-window-item value="workflow"><WorkflowTab/></v-window-item>
+      <v-window-item value="selfplay"><SelfPlayTab/></v-window-item>
+      <v-window-item value="export"><ExportTab/></v-window-item>
     </v-window>
   </v-container>
+  <v-alert v-if="!plannedEnabled" density="compact" type="info" variant="tonal" class="mt-4">
+    Backend-Endpunkte für Konfiguration/Workflow sind (noch) nicht aktiv. Buttons sind daher deaktiviert.
+  </v-alert>
 </template>
-
 <script setup lang="ts">
 import { ref } from 'vue'
-
+import ModelSetupTab from '@/sections/config/ModelSetupTab.vue'
+import DatasetSelectionTab from '@/sections/config/DatasetSelectionTab.vue'
+import WorkflowTab from '@/sections/config/WorkflowTab.vue'
+import SelfPlayTab from '@/sections/config/SelfPlayTab.vue'
+import ExportTab from '@/sections/config/ExportTab.vue'
+import { usePlanned } from '@/composables/usePlanned'
 const tab = ref('model')
+const { plannedEnabled } = usePlanned()
 </script>
-

--- a/frontend/src/sections/config/DatasetSelectionTab.vue
+++ b/frontend/src/sections/config/DatasetSelectionTab.vue
@@ -1,0 +1,39 @@
+<template>
+  <v-row>
+    <v-col cols="12" md="6">
+      <v-autocomplete
+        v-model="selected"
+        :items="datasets"
+        item-title="name"
+        item-value="id"
+        label="Datasets"
+        multiple chips
+      />
+      <div class="d-flex gap-4">
+        <v-text-field label="Train %" v-model.number="split.train" type="number"/>
+        <v-text-field label="Val %" v-model.number="split.val" type="number"/>
+        <v-text-field label="Test %" v-model.number="split.test" type="number"/>
+      </div>
+      <v-btn color="primary" class="mt-2" @click="apply" :disabled="!plannedEnabled">Apply Selection</v-btn>
+    </v-col>
+    <v-col cols="12" md="6">
+      <v-alert type="info" variant="tonal">Verteilungen & Größen folgen (Charts)</v-alert>
+    </v-col>
+  </v-row>
+</template>
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import api from '@/plugins/axios'
+import { usePlanned } from '@/composables/usePlanned'
+const { plannedEnabled } = usePlanned()
+const datasets = ref<{id:string; name:string}[]>([])
+const selected = ref<string[]>([])
+const split = ref({ train:80, val:10, test:10 })
+onMounted(async ()=>{
+  try { const { data } = await api.get('/v1/datasets'); datasets.value = data.items||data } catch {}
+})
+async function apply(){
+  if(!plannedEnabled) return
+  await api.post('/v1/config/datasets', { ids:selected.value, split: split.value })
+}
+</script>

--- a/frontend/src/sections/config/ExportTab.vue
+++ b/frontend/src/sections/config/ExportTab.vue
@@ -1,0 +1,4 @@
+<template>
+  <v-alert type="info">Planned: POST /v1/export/state</v-alert>
+</template>
+<script setup lang="ts"></script>

--- a/frontend/src/sections/config/ExportTab.vue
+++ b/frontend/src/sections/config/ExportTab.vue
@@ -1,4 +1,19 @@
 <template>
-  <v-alert type="info">Planned: POST /v1/export/state</v-alert>
+  <v-checkbox v-model="inc.datasets" label="Datasets"/>
+  <v-checkbox v-model="inc.models" label="Models"/>
+  <v-checkbox v-model="inc.reports" label="Reports"/>
+  <v-btn class="mt-2" color="primary" @click="doExport" :disabled="!plannedEnabled">Export Snapshot</v-btn>
+  <div v-if="uri" class="mt-2">Export URI: <code>{{ uri }}</code></div>
 </template>
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import api from '@/plugins/axios'
+import { usePlanned } from '@/composables/usePlanned'
+const { plannedEnabled } = usePlanned()
+const inc = $ref({ datasets:true, models:true, reports:false })
+const uri = $ref<string|null>(null)
+async function doExport(){
+  if(!plannedEnabled) return
+  const { data } = await api.post('/v1/export/state', { include: inc })
+  uri.value = data?.reportUri || data?.uri || null
+}
+</script>

--- a/frontend/src/sections/config/ModelSetupTab.vue
+++ b/frontend/src/sections/config/ModelSetupTab.vue
@@ -1,0 +1,27 @@
+<template>
+  <v-form @submit.prevent="save">
+    <div class="d-flex gap-4 flex-wrap">
+      <v-select label="Preset" v-model="preset" :items="presets"/>
+      <v-text-field label="Learning Rate" v-model.number="hp.lr" type="number" step="0.0001"/>
+      <v-text-field label="Batch Size" v-model.number="hp.batchSize" type="number" step="1"/>
+      <v-text-field label="Epochs" v-model.number="hp.epochs" type="number"/>
+      <v-text-field label="Temperature" v-model.number="hp.temperature" type="number" step="0.1"/>
+      <v-text-field label="Top-k" v-model.number="hp.topk" type="number"/>
+    </div>
+    <v-btn class="mt-3" color="primary" type="submit" :disabled="!plannedEnabled">Save Preset</v-btn>
+  </v-form>
+</template>
+<script setup lang="ts">
+import { ref } from 'vue'
+import api from '@/plugins/axios'
+import { usePlanned } from '@/composables/usePlanned'
+import type { HyperParams, ModelPreset } from '@/types/config'
+const { plannedEnabled } = usePlanned()
+const presets:ModelPreset[] = ['policy_tiny','policy_small','custom']
+const preset = ref<ModelPreset>('policy_tiny')
+const hp = ref<HyperParams>({ lr:0.001, batchSize:64, epochs:10, temperature:0.8, topk:5 })
+async function save(){
+  if(!plannedEnabled) return
+  await api.post('/v1/config/model', { preset: preset.value, params: hp.value })
+}
+</script>

--- a/frontend/src/sections/config/SelfPlayTab.vue
+++ b/frontend/src/sections/config/SelfPlayTab.vue
@@ -1,0 +1,4 @@
+<template>
+  <v-alert type="info">Planned: POST /v1/selfplay</v-alert>
+</template>
+<script setup lang="ts"></script>

--- a/frontend/src/sections/config/SelfPlayTab.vue
+++ b/frontend/src/sections/config/SelfPlayTab.vue
@@ -1,4 +1,20 @@
 <template>
-  <v-alert type="info">Planned: POST /v1/selfplay</v-alert>
+  <div class="d-flex gap-4 flex-wrap">
+    <v-text-field label="Games" v-model.number="games" type="number"/>
+    <v-select label="Time Control" v-model="tc" :items="['1+0','3+2','5+0','10+0']"/>
+    <v-text-field label="Concurrency" v-model.number="conc" type="number"/>
+  </div>
+  <v-btn class="mt-2" color="primary" @click="start" :disabled="!plannedEnabled">Start Self-Play</v-btn>
 </template>
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import api from '@/plugins/axios'
+import { usePlanned } from '@/composables/usePlanned'
+const { plannedEnabled } = usePlanned()
+const games = $ref(100)
+const tc = $ref('3+2')
+const conc = $ref(2)
+async function start(){
+  if(!plannedEnabled) return
+  await api.post('/v1/selfplay', { games, timeControl:tc, concurrency:conc })
+}
+</script>

--- a/frontend/src/sections/config/WorkflowTab.vue
+++ b/frontend/src/sections/config/WorkflowTab.vue
@@ -1,0 +1,4 @@
+<template>
+  <v-alert type="info">Planned: POST /v1/workflows</v-alert>
+</template>
+<script setup lang="ts"></script>

--- a/frontend/src/sections/config/WorkflowTab.vue
+++ b/frontend/src/sections/config/WorkflowTab.vue
@@ -1,4 +1,15 @@
 <template>
-  <v-alert type="info">Planned: POST /v1/workflows</v-alert>
+  <v-checkbox v-for="s in steps" :key="s" v-model="active" :label="s" :value="s"/>
+  <v-btn class="mt-2" color="primary" @click="run" :disabled="!plannedEnabled">Run Workflow</v-btn>
 </template>
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import api from '@/plugins/axios'
+import { usePlanned } from '@/composables/usePlanned'
+const { plannedEnabled } = usePlanned()
+const steps = ['Ingest','Build Datasets','Train','Evaluate','Promote']
+const active = $ref<string[]>(['Ingest','Build Datasets','Train'])
+async function run(){
+  if(!plannedEnabled) return
+  await api.post('/v1/workflows', { steps: active })
+}
+</script>

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -1,0 +1,2 @@
+export type HyperParams = { lr:number; batchSize:number; epochs:number; temperature:number; topk:number }
+export type ModelPreset = 'policy_tiny'|'policy_small'|'custom'

--- a/frontend/tests/config.disabled.spec.ts
+++ b/frontend/tests/config.disabled.spec.ts
@@ -1,0 +1,6 @@
+import { describe, it, expect } from 'vitest'
+describe('planned endpoints flag', ()=>{
+  it('is disabled by default', ()=>{
+    expect(import.meta.env.VITE_ENABLE_CONFIG_ENDPOINTS).not.toBe('true')
+  })
+})


### PR DESCRIPTION
## Summary
- add example environment variables including feature toggle for config endpoints
- implement composables and types for planned config features
- introduce model setup and dataset selection tabs in ConfigWorkbench

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/markdown-link-check)*
- `npm run lint` *(fails: The 'jiti' library is required for loading TypeScript configuration files)*
- `npm run test:unit` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b4fd927c832b8c88c7c3da0a1799