### PR TITLE
style: enhance navigation colors

### DIFF
--- a/frontend/src/layouts/BaseFrame.vue
+++ b/frontend/src/layouts/BaseFrame.vue
@@ -1,6 +1,6 @@
 <template>
    <v-app theme="chsDark">
-    <v-navigation-drawer rail expand-on-hover app>
+    <v-navigation-drawer class="chs-nav" color="surface" rail expand-on-hover app>
       <v-list nav density="comfortable">
         <v-list-item to="/" prepend-icon="mdi-view-dashboard" title="Overview" />
         <v-list-item to="/config" prepend-icon="mdi-tune" title="Configuration" />
@@ -9,7 +9,7 @@
       </v-list>
     </v-navigation-drawer>
 
-    <v-app-bar class="chs-appbar">
+    <v-app-bar app class="chs-appbar" color="surface">
       <v-container class="d-flex align-center">
         <v-icon class="mr-3" color="primary">mdi-crown</v-icon>
         <span class="text-h6">ChessApp</span>

--- a/frontend/src/pages/Overview.vue
+++ b/frontend/src/pages/Overview.vue
@@ -16,7 +16,7 @@
     <v-row dense class="mt-2">
       <v-col cols="12" md="7">
         <v-card class="chs-card" min-height="280">
-          <v-card-title class="text-subtitle-1" style="color:#EBD6A2">Training Loss</v-card-title>
+          <v-card-title class="text-subtitle-1" style="color:#CBA35C">Training Loss</v-card-title>
           <v-divider class="chs-divider" />
           <div class="pa-4">
             <!-- Chart placeholder; später via vue-echarts/chart.js -->
@@ -27,7 +27,7 @@
 
       <v-col cols="12" md="5">
         <v-card class="chs-card" min-height="280">
-          <v-card-title class="text-subtitle-1" style="color:#EBD6A2">Recent Trainings</v-card-title>
+          <v-card-title class="text-subtitle-1" style="color:#CBA35C">Recent Trainings</v-card-title>
           <v-divider class="chs-divider" />
           <v-table density="comfortable">
             <thead>
@@ -49,7 +49,7 @@
     <v-row dense class="mt-2">
       <v-col cols="12" md="7">
         <v-card class="chs-card" min-height="260">
-          <v-card-title class="text-subtitle-1" style="color:#EBD6A2">Requests/sec</v-card-title>
+          <v-card-title class="text-subtitle-1" style="color:#CBA35C">Requests/sec</v-card-title>
           <v-divider class="chs-divider" />
           <div class="pa-4">
             <div style="height:200px; border:1px dashed rgba(203,163,92,.25); border-radius:8px;"></div>
@@ -59,7 +59,7 @@
 
       <v-col cols="12" md="5">
         <v-card class="chs-card" min-height="260">
-          <v-card-title class="text-subtitle-1" style="color:#EBD6A2">Promo / Mini-Board</v-card-title>
+          <v-card-title class="text-subtitle-1" style="color:#CBA35C">Promo / Mini-Board</v-card-title>
           <v-divider class="chs-divider" />
           <div class="pa-4 d-flex align-center justify-center" style="height:200px;">
             <v-icon size="96" color="primary">mdi-crown</v-icon>

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -20,11 +20,15 @@ body {
 
 .mono { font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace; }
 
-/* Nav */
-.chs-nav {
+/* Nav (Drawer) */
+.chs-nav{
   background: linear-gradient(180deg, #0C1916, #0A1513);
   border-right: 1px solid rgba(203,163,92,0.10);
+  color: var(--chs-brass); /* Nav-Text gold */
 }
+.chs-nav .v-list-item-title,
+.chs-nav .v-icon { color: var(--chs-brass) !important; }
+.chs-nav .v-list-item--active { background: rgba(203,163,92,0.10) !important; }
 
 /* Divider */
 .chs-divider { border-color: rgba(203,163,92,0.18) !important; }
@@ -37,6 +41,7 @@ body {
     0 10px 24px rgba(203,163,92,0.10), /* brass glow */
     0 2px 10px rgba(0,0,0,0.35);
   border: 1px solid rgba(203,163,92,0.15);
+  color: var(--chs-brass); /* Text auf dunklen Flächen gold */
 }
 
 /* KPI helper */
@@ -44,19 +49,23 @@ body {
 .chs-kpi .label { color: rgba(237,237,237,0.75); font-size: 14px; }
 .chs-kpi .value { font-size: 42px; font-weight: 600; letter-spacing: .5px; color: var(--chs-brass); }
 
-/* Section wrapper for page blocks */
+/* Section wrapper */
 .chs-section { padding: 16px; border: 1px solid rgba(203,163,92,0.10); border-radius: 14px; background: #0E1C19; }
 
+/* Buttons – Schriftfarbe weiß (alle Varianten) */
+.v-btn, .v-btn .v-btn__content { color: #FFFFFF !important; }
+.v-btn--variant-outlined { border-color: rgba(203,163,92,0.60) !important; }
 
-/* Vuetify App-Hintergrund transparent halten (sonst weißer Mittelbereich) */
+/* Vuetify App-Hintergrund transparent lassen */
 .v-application { background: transparent !important; }
 
-/* Main Padding global; Seiten entscheiden selbst über Container/Grids */
+/* Main Padding */
 .chs-main { padding: 24px; }
 
-/* AppBar leicht abgedunkelt + feine Brass-Linie */
+/* AppBar – dunkel & integriert */
 .chs-appbar {
   background: rgba(15,31,28,0.85) !important;
   backdrop-filter: blur(2px);
   border-bottom: 1px solid rgba(203,163,92,0.10);
+  color: var(--chs-brass); /* Header-Text gold */
 }


### PR DESCRIPTION
## Summary
- register app bar with layout and color navigation drawer using surface theme
- style nav, buttons, and cards with brass-on-dark branding
- use brass for overview card titles

## Testing
- `npm --prefix frontend run test:unit` *(fails: vitest: not found)*
- `npm --prefix frontend run lint` *(fails: jiti required for ESLint config)*
- `pytest -q` *(fails: ModuleNotFoundError: config)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cc6bc618832b874b5d2e4c696a2c