### PR TITLE
feat: expose metrics and logs endpoints

### DIFF
--- a/api/api-app/src/main/java/com/chessapp/api/common/dto/Series.java
+++ b/api/api-app/src/main/java/com/chessapp/api/common/dto/Series.java
@@ -1,0 +1,5 @@
+package com.chessapp.api.common.dto;
+
+import java.util.List;
+
+public record Series(String label, List<TimeSeriesPoint> points) {}

--- a/api/api-app/src/main/java/com/chessapp/api/common/dto/SeriesResponse.java
+++ b/api/api-app/src/main/java/com/chessapp/api/common/dto/SeriesResponse.java
@@ -1,0 +1,5 @@
+package com.chessapp.api.common.dto;
+
+import java.util.List;
+
+public record SeriesResponse(List<Series> series) {}

--- a/api/api-app/src/main/java/com/chessapp/api/common/dto/SingleValueDto.java
+++ b/api/api-app/src/main/java/com/chessapp/api/common/dto/SingleValueDto.java
@@ -1,0 +1,3 @@
+package com.chessapp.api.common.dto;
+
+public record SingleValueDto(double value, String unit) {}

--- a/api/api-app/src/main/java/com/chessapp/api/common/dto/TimeSeriesPoint.java
+++ b/api/api-app/src/main/java/com/chessapp/api/common/dto/TimeSeriesPoint.java
@@ -1,0 +1,3 @@
+package com.chessapp.api.common.dto;
+
+public record TimeSeriesPoint(long ts, double value) {}

--- a/api/api-app/src/main/java/com/chessapp/api/datasets/api/DatasetsController.java
+++ b/api/api-app/src/main/java/com/chessapp/api/datasets/api/DatasetsController.java
@@ -1,0 +1,47 @@
+package com.chessapp.api.datasets.api;
+
+import com.chessapp.api.datasets.api.dto.*;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/v1/datasets")
+public class DatasetsController {
+
+    @GetMapping("/{id}/summary")
+    public SummaryDto summary(@PathVariable String id) {
+        return new SummaryDto(id, 0L, 0L, 0);
+    }
+
+    @GetMapping("/{id}/versions")
+    public VersionsDto versions(@PathVariable String id) {
+        var item = new VersionItemDto("v1", Instant.now().toString());
+        return new VersionsDto(1, "v1", List.of(item));
+    }
+
+    @GetMapping("/{id}/schema")
+    public SchemaDto schema(@PathVariable String id) {
+        var col = new ColumnDto("col", "string", 0.0, 0.0, null, null);
+        return new SchemaDto(List.of(col));
+    }
+
+    @GetMapping("/{id}/sample")
+    public SampleDto sample(@PathVariable String id,
+                             @RequestParam(defaultValue="10") int limit,
+                             @RequestParam(required=false) String cursor) {
+        return new SampleDto(List.of(Map.of()), null);
+    }
+
+    @GetMapping("/{id}/quality")
+    public QualityDto quality(@PathVariable String id) {
+        return new QualityDto(0.0, 0.0, 0.0);
+    }
+
+    @GetMapping("/{id}/ingest/history")
+    public IngestHistoryDto history(@PathVariable String id) {
+        return new IngestHistoryDto(List.of());
+    }
+}

--- a/api/api-app/src/main/java/com/chessapp/api/datasets/api/dto/ColumnDto.java
+++ b/api/api-app/src/main/java/com/chessapp/api/datasets/api/dto/ColumnDto.java
@@ -1,0 +1,3 @@
+package com.chessapp.api.datasets.api.dto;
+
+public record ColumnDto(String name, String dtype, double nullPct, double uniquePct, String min, String max) {}

--- a/api/api-app/src/main/java/com/chessapp/api/datasets/api/dto/IngestHistoryDto.java
+++ b/api/api-app/src/main/java/com/chessapp/api/datasets/api/dto/IngestHistoryDto.java
@@ -1,0 +1,5 @@
+package com.chessapp.api.datasets.api.dto;
+
+import java.util.List;
+
+public record IngestHistoryDto(List<IngestHistoryItemDto> items) {}

--- a/api/api-app/src/main/java/com/chessapp/api/datasets/api/dto/IngestHistoryItemDto.java
+++ b/api/api-app/src/main/java/com/chessapp/api/datasets/api/dto/IngestHistoryItemDto.java
@@ -1,0 +1,3 @@
+package com.chessapp.api.datasets.api.dto;
+
+public record IngestHistoryItemDto(String at, String user, String note, String version) {}

--- a/api/api-app/src/main/java/com/chessapp/api/datasets/api/dto/QualityDto.java
+++ b/api/api-app/src/main/java/com/chessapp/api/datasets/api/dto/QualityDto.java
@@ -1,0 +1,3 @@
+package com.chessapp.api.datasets.api.dto;
+
+public record QualityDto(double missingPct, double outlierPct, double duplicatePct) {}

--- a/api/api-app/src/main/java/com/chessapp/api/datasets/api/dto/SampleDto.java
+++ b/api/api-app/src/main/java/com/chessapp/api/datasets/api/dto/SampleDto.java
@@ -1,0 +1,6 @@
+package com.chessapp.api.datasets.api.dto;
+
+import java.util.List;
+import java.util.Map;
+
+public record SampleDto(List<Map<String, Object>> items, String nextCursor) {}

--- a/api/api-app/src/main/java/com/chessapp/api/datasets/api/dto/SchemaDto.java
+++ b/api/api-app/src/main/java/com/chessapp/api/datasets/api/dto/SchemaDto.java
@@ -1,0 +1,5 @@
+package com.chessapp.api.datasets.api.dto;
+
+import java.util.List;
+
+public record SchemaDto(List<ColumnDto> columns) {}

--- a/api/api-app/src/main/java/com/chessapp/api/datasets/api/dto/SummaryDto.java
+++ b/api/api-app/src/main/java/com/chessapp/api/datasets/api/dto/SummaryDto.java
@@ -1,0 +1,3 @@
+package com.chessapp.api.datasets.api.dto;
+
+public record SummaryDto(String id, long rows, long sizeBytes, int classes) {}

--- a/api/api-app/src/main/java/com/chessapp/api/datasets/api/dto/VersionItemDto.java
+++ b/api/api-app/src/main/java/com/chessapp/api/datasets/api/dto/VersionItemDto.java
@@ -1,0 +1,3 @@
+package com.chessapp.api.datasets.api.dto;
+
+public record VersionItemDto(String version, String createdAt) {}

--- a/api/api-app/src/main/java/com/chessapp/api/datasets/api/dto/VersionsDto.java
+++ b/api/api-app/src/main/java/com/chessapp/api/datasets/api/dto/VersionsDto.java
@@ -1,0 +1,5 @@
+package com.chessapp.api.datasets.api.dto;
+
+import java.util.List;
+
+public record VersionsDto(int count, String latest, List<VersionItemDto> items) {}

--- a/api/api-app/src/main/java/com/chessapp/api/logs/api/LogsController.java
+++ b/api/api-app/src/main/java/com/chessapp/api/logs/api/LogsController.java
@@ -1,0 +1,50 @@
+package com.chessapp.api.logs.api;
+
+import com.chessapp.api.logs.api.dto.*;
+import com.chessapp.api.metrics.service.ObsProxyClient;
+import com.chessapp.api.metrics.service.RangeHelper;
+import com.chessapp.api.metrics.service.RangeParams;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.util.*;
+
+@RestController
+@RequestMapping("/v1/logs")
+public class LogsController {
+
+    private final ObsProxyClient client;
+    public LogsController(ObsProxyClient client) { this.client = client; }
+
+    @GetMapping("/training/{runId}")
+    public LogListDto training(@PathVariable String runId,
+                               @RequestParam(defaultValue="2h") String range,
+                               @RequestParam(defaultValue="500") int limit,
+                               @RequestParam(defaultValue="backward") String direction) {
+        RangeParams rp = RangeHelper.mapRange(range);
+        String q = "{app=\"trainer\",run_id=\""+runId+"\"}";
+        Map<String,Object> resp;
+        try {
+            resp = client.lokiRange(q, rp.start(), rp.end(), limit, direction);
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "upstream error");
+        }
+        List<LogItemDto> items = new ArrayList<>();
+        Map<String,Object> data = (Map<String,Object>) resp.getOrDefault("data", Map.of());
+        List<Map<String,Object>> result = (List<Map<String,Object>>) data.getOrDefault("result", List.of());
+        for (Map<String,Object> stream : result) {
+            Map<String,Object> streamMeta = (Map<String,Object>) stream.getOrDefault("stream", Map.of());
+            String level = String.valueOf(streamMeta.getOrDefault("level", "INFO"));
+            List<List<Object>> values = (List<List<Object>>) stream.getOrDefault("values", List.of());
+            for (List<Object> v : values) {
+                String tsStr = String.valueOf(v.get(0));
+                long ns = Long.parseLong(tsStr);
+                String msg = String.valueOf(v.get(1));
+                items.add(new LogItemDto(Instant.ofEpochMilli(ns/1_000_000).toString(), level, msg));
+            }
+        }
+        return new LogListDto(items);
+    }
+}

--- a/api/api-app/src/main/java/com/chessapp/api/logs/api/dto/LogItemDto.java
+++ b/api/api-app/src/main/java/com/chessapp/api/logs/api/dto/LogItemDto.java
@@ -1,0 +1,3 @@
+package com.chessapp.api.logs.api.dto;
+
+public record LogItemDto(String ts, String level, String msg) {}

--- a/api/api-app/src/main/java/com/chessapp/api/logs/api/dto/LogListDto.java
+++ b/api/api-app/src/main/java/com/chessapp/api/logs/api/dto/LogListDto.java
@@ -1,0 +1,5 @@
+package com.chessapp.api.logs.api.dto;
+
+import java.util.List;
+
+public record LogListDto(List<LogItemDto> items) {}

--- a/api/api-app/src/main/java/com/chessapp/api/metrics/api/MetricsController.java
+++ b/api/api-app/src/main/java/com/chessapp/api/metrics/api/MetricsController.java
@@ -1,0 +1,133 @@
+package com.chessapp.api.metrics.api;
+
+import com.chessapp.api.common.dto.*;
+import com.chessapp.api.metrics.service.ObsProxyClient;
+import com.chessapp.api.metrics.service.RangeHelper;
+import com.chessapp.api.metrics.service.RangeParams;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.*;
+
+@RestController
+@RequestMapping("/v1/metrics")
+public class MetricsController {
+
+    private final ObsProxyClient client;
+    public MetricsController(ObsProxyClient client) { this.client = client; }
+
+    private Series toSeries(Map<String,Object> prom, String label) {
+        Map<String,Object> data = (Map<String,Object>) prom.getOrDefault("data", Map.of());
+        List<Map<String,Object>> res = (List<Map<String,Object>>) data.getOrDefault("result", List.of());
+        List<TimeSeriesPoint> pts = new ArrayList<>();
+        if (!res.isEmpty()) {
+            List<List<Object>> values = (List<List<Object>>) res.get(0).getOrDefault("values", List.of());
+            for (List<Object> v : values) {
+                long ts = ((Number) v.get(0)).longValue();
+                double val = Double.parseDouble(String.valueOf(v.get(1)));
+                pts.add(new TimeSeriesPoint(ts, val));
+            }
+        }
+        return new Series(label, pts);
+    }
+
+    private double lastValue(Map<String,Object> prom) {
+        Map<String,Object> data = (Map<String,Object>) prom.getOrDefault("data", Map.of());
+        List<Map<String,Object>> res = (List<Map<String,Object>>) data.getOrDefault("result", List.of());
+        if (!res.isEmpty()) {
+            List<List<Object>> values = (List<List<Object>>) res.get(0).getOrDefault("values", List.of());
+            if (!values.isEmpty()) {
+                List<Object> last = values.get(values.size()-1);
+                return Double.parseDouble(String.valueOf(last.get(1)));
+            }
+        }
+        return 0.0;
+    }
+
+    @GetMapping("/throughput")
+    public SeriesResponse throughput(@RequestParam String runId,
+                                     @RequestParam(defaultValue = "2h") String range) {
+        RangeParams rp = RangeHelper.mapRange(range);
+        String q = "avg_over_time(chs_training_it_per_sec{run_id=\"" + runId + "\"}[5m])";
+        Series s = toSeries(client.promRange(q, rp.start(), rp.end(), rp.step()), "throughput_it_per_sec");
+        return new SeriesResponse(List.of(s));
+    }
+
+    @GetMapping("/training/{runId}")
+    public SeriesResponse training(@PathVariable String runId,
+                                   @RequestParam String m,
+                                   @RequestParam(defaultValue = "24h") String range) {
+        RangeParams rp = RangeHelper.mapRange(range);
+        List<Series> out = new ArrayList<>();
+        for (String metric : m.split(",")) {
+            String q;
+            String label;
+            switch (metric.trim()) {
+                case "loss" -> { q = "avg_over_time(ml_training_loss{run_id=\""+runId+"\"}[5m])"; label = "loss"; }
+                case "val_acc" -> { q = "avg_over_time(ml_training_val_acc{run_id=\""+runId+"\"}[5m])"; label = "val_acc"; }
+                default -> continue;
+            }
+            out.add(toSeries(client.promRange(q, rp.start(), rp.end(), rp.step()), label));
+        }
+        return new SeriesResponse(out);
+    }
+
+    @GetMapping("/utilization")
+    public SeriesResponse util(@RequestParam(required=false) String runId,
+                               @RequestParam(defaultValue="24h") String range) {
+        RangeParams rp = RangeHelper.mapRange(range);
+        List<Series> out = new ArrayList<>();
+        String cpuQ = "avg_over_time(node_cpu_seconds_total{mode!=\"idle\"}[5m])";
+        out.add(toSeries(client.promRange(cpuQ, rp.start(), rp.end(), rp.step()), "cpu_pct"));
+        if (runId != null) {
+            String gpuQ = "avg_over_time(chs_gpu_utilization_pct{run_id=\""+runId+"\"}[5m])";
+            String memQ = "avg_over_time(chs_gpu_mem_used_pct{run_id=\""+runId+"\"}[5m])";
+            out.add(toSeries(client.promRange(gpuQ, rp.start(), rp.end(), rp.step()), "gpu_pct"));
+            out.add(toSeries(client.promRange(memQ, rp.start(), rp.end(), rp.step()), "vram_pct"));
+        } else {
+            out.add(new Series("gpu_pct", List.of()));
+            out.add(new Series("vram_pct", List.of()));
+        }
+        return new SeriesResponse(out);
+    }
+
+    @GetMapping("/latency")
+    public SingleValueDto latency(@RequestParam int p) {
+        String q = "histogram_quantile(0." + p + ", sum by (le) (rate(http_server_requests_seconds_bucket[5m]))) * 1000";
+        long end = java.time.Instant.now().getEpochSecond();
+        long start = end - 300;
+        double v = lastValue(client.promRange(q, start, end, "300s"));
+        return new SingleValueDto(v, "ms");
+    }
+
+    @GetMapping("/mps")
+    public SeriesResponse mps(@RequestParam(defaultValue="24h") String range) {
+        RangeParams rp = RangeHelper.mapRange(range);
+        String q = "sum(rate(chs_moves_total[1m]))";
+        Series s = toSeries(client.promRange(q, rp.start(), rp.end(), rp.step()), "mps");
+        return new SeriesResponse(List.of(s));
+    }
+
+    @GetMapping("/rps")
+    public SeriesResponse rps(@RequestParam(defaultValue="24h") String range) {
+        RangeParams rp = RangeHelper.mapRange(range);
+        String q = "sum(rate(http_server_requests_seconds_count[1m]))";
+        Series s = toSeries(client.promRange(q, rp.start(), rp.end(), rp.step()), "rps");
+        return new SeriesResponse(List.of(s));
+    }
+
+    @GetMapping("/error_rate")
+    public SeriesResponse errorRate(@RequestParam(defaultValue="24h") String range) {
+        RangeParams rp = RangeHelper.mapRange(range);
+        String q = "increase(http_server_requests_seconds_count{status=~\"5..\"}[5m]) / increase(http_server_requests_seconds_count[5m])";
+        Series s = toSeries(client.promRange(q, rp.start(), rp.end(), rp.step()), "error_rate");
+        return new SeriesResponse(List.of(s));
+    }
+
+    @GetMapping("/elo")
+    public SeriesResponse elo(@RequestParam(defaultValue="30d") String range) {
+        RangeParams rp = RangeHelper.mapRange(range);
+        String q = "avg_over_time(chs_engine_elo[1h])";
+        Series s = toSeries(client.promRange(q, rp.start(), rp.end(), rp.step()), "elo");
+        return new SeriesResponse(List.of(s));
+    }
+}

--- a/api/api-app/src/main/java/com/chessapp/api/metrics/service/ObsProxyClient.java
+++ b/api/api-app/src/main/java/com/chessapp/api/metrics/service/ObsProxyClient.java
@@ -1,0 +1,8 @@
+package com.chessapp.api.metrics.service;
+
+import java.util.Map;
+
+public interface ObsProxyClient {
+    Map<String, Object> promRange(String query, long start, long end, String step);
+    Map<String, Object> lokiRange(String query, long start, long end, int limit, String direction);
+}

--- a/api/api-app/src/main/java/com/chessapp/api/metrics/service/ObsProxyClientWeb.java
+++ b/api/api-app/src/main/java/com/chessapp/api/metrics/service/ObsProxyClientWeb.java
@@ -1,0 +1,53 @@
+package com.chessapp.api.metrics.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
+
+@Component
+public class ObsProxyClientWeb implements ObsProxyClient {
+
+    private final WebClient web;
+
+    public ObsProxyClientWeb(@Value("${chs.obs.base-url:http://obs-proxy:8080}") String baseUrl) {
+        this.web = WebClient.builder().baseUrl(baseUrl).build();
+    }
+
+    @Override
+    public Map<String, Object> promRange(String query, long start, long end, String step) {
+        try {
+            return web.get().uri(uriBuilder -> uriBuilder.path("/obs/prom/range")
+                    .queryParam("query", query)
+                    .queryParam("start", start)
+                    .queryParam("end", end)
+                    .queryParam("step", step)
+                    .build())
+                    .retrieve()
+                    .bodyToMono(new ParameterizedTypeReference<Map<String,Object>>() {})
+                    .block();
+        } catch (Exception e) {
+            return Map.of("data", Map.of("result", java.util.List.of()));
+        }
+    }
+
+    @Override
+    public Map<String, Object> lokiRange(String query, long start, long end, int limit, String direction) {
+        try {
+            return web.get().uri(uriBuilder -> uriBuilder.path("/obs/loki/query_range")
+                    .queryParam("query", query)
+                    .queryParam("start", start)
+                    .queryParam("end", end)
+                    .queryParam("limit", limit)
+                    .queryParam("direction", direction)
+                    .build())
+                    .retrieve()
+                    .bodyToMono(new ParameterizedTypeReference<Map<String,Object>>() {})
+                    .block();
+        } catch (Exception e) {
+            return Map.of("data", Map.of("result", java.util.List.of()));
+        }
+    }
+}

--- a/api/api-app/src/main/java/com/chessapp/api/metrics/service/RangeHelper.java
+++ b/api/api-app/src/main/java/com/chessapp/api/metrics/service/RangeHelper.java
@@ -1,0 +1,22 @@
+package com.chessapp.api.metrics.service;
+
+import java.time.Duration;
+import java.time.Instant;
+
+public final class RangeHelper {
+    private RangeHelper() {}
+
+    public static RangeParams mapRange(String range) {
+        Instant end = Instant.now();
+        Instant start;
+        String step;
+        switch (range) {
+            case "2h" -> { start = end.minus(Duration.ofHours(2)); step = "60s"; }
+            case "24h" -> { start = end.minus(Duration.ofHours(24)); step = "300s"; }
+            case "7d" -> { start = end.minus(Duration.ofDays(7)); step = "1800s"; }
+            case "30d" -> { start = end.minus(Duration.ofDays(30)); step = "7200s"; }
+            default -> { start = end.minus(Duration.ofHours(2)); step = "60s"; }
+        }
+        return new RangeParams(start.getEpochSecond(), end.getEpochSecond(), step);
+    }
+}

--- a/api/api-app/src/main/java/com/chessapp/api/metrics/service/RangeParams.java
+++ b/api/api-app/src/main/java/com/chessapp/api/metrics/service/RangeParams.java
@@ -1,0 +1,3 @@
+package com.chessapp.api.metrics.service;
+
+public record RangeParams(long start, long end, String step) {}

--- a/api/api-app/src/main/java/com/chessapp/api/training/api/TrainingAliasController.java
+++ b/api/api-app/src/main/java/com/chessapp/api/training/api/TrainingAliasController.java
@@ -1,0 +1,14 @@
+package com.chessapp.api.training.api;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Controller
+public class TrainingAliasController {
+
+    @GetMapping("/v1/training/{runId}")
+    public String alias(@PathVariable String runId) {
+        return "forward:/v1/trainings/" + runId;
+    }
+}

--- a/api/api-app/src/main/java/com/chessapp/api/training/service/TrainingService.java
+++ b/api/api-app/src/main/java/com/chessapp/api/training/service/TrainingService.java
@@ -73,6 +73,13 @@ public class TrainingService {
         out.putIfAbsent("etaSec", null);
         out.putIfAbsent("step", 0);
         out.putIfAbsent("epoch", 0);
+        if (ml.get("updatedAt") != null) {
+            out.put("updatedAt", ml.get("updatedAt"));
+        } else if (tr != null) {
+            Instant upd = tr.getFinishedAt() != null ? tr.getFinishedAt() : Instant.now();
+            out.put("updatedAt", upd.toString());
+        }
+        out.putIfAbsent("updatedAt", Instant.now().toString());
         return out;
     }
 

--- a/api/api-app/src/test/java/com/chessapp/api/datasets/DatasetsControllerTest.java
+++ b/api/api-app/src/test/java/com/chessapp/api/datasets/DatasetsControllerTest.java
@@ -1,0 +1,27 @@
+package com.chessapp.api.datasets;
+
+import com.chessapp.api.testutil.AbstractIntegrationTest;
+import com.chessapp.api.testutil.TestAuth;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(properties = {"logging.config=classpath:logback-spring.xml"},
+        classes = com.chessapp.api.codex.CodexApplication.class)
+@AutoConfigureMockMvc
+class DatasetsControllerTest extends AbstractIntegrationTest {
+
+    @Autowired MockMvc mvc;
+
+    @Test
+    void summary_ok() throws Exception {
+        mvc.perform(get("/v1/datasets/abc/summary").with(TestAuth.jwtUser()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value("abc"));
+    }
+}

--- a/api/api-app/src/test/java/com/chessapp/api/logs/LogsControllerTest.java
+++ b/api/api-app/src/test/java/com/chessapp/api/logs/LogsControllerTest.java
@@ -1,0 +1,40 @@
+package com.chessapp.api.logs;
+
+import com.chessapp.api.metrics.service.ObsProxyClient;
+import com.chessapp.api.testutil.AbstractIntegrationTest;
+import com.chessapp.api.testutil.TestAuth;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(properties = {"logging.config=classpath:logback-spring.xml"},
+        classes = com.chessapp.api.codex.CodexApplication.class)
+@AutoConfigureMockMvc
+class LogsControllerTest extends AbstractIntegrationTest {
+
+    @Autowired MockMvc mvc;
+    @MockBean ObsProxyClient obs;
+
+    @Test
+    void training_logs_ok() throws Exception {
+        Map<String,Object> loki = Map.of("data", Map.of("result", List.of(Map.of(
+                "stream", Map.of("level","INFO"),
+                "values", List.of(List.of("1","hello"))
+        ))));
+        when(obs.lokiRange(any(), any(Long.class), any(Long.class), any(Integer.class), any())).thenReturn(loki);
+        mvc.perform(get("/v1/logs/training/abc").with(TestAuth.jwtUser()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items[0].msg").value("hello"));
+    }
+}

--- a/api/api-app/src/test/java/com/chessapp/api/metrics/MetricsControllerTest.java
+++ b/api/api-app/src/test/java/com/chessapp/api/metrics/MetricsControllerTest.java
@@ -1,0 +1,48 @@
+package com.chessapp.api.metrics;
+
+import com.chessapp.api.metrics.service.ObsProxyClient;
+import com.chessapp.api.testutil.AbstractIntegrationTest;
+import com.chessapp.api.testutil.TestAuth;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(properties = {"logging.config=classpath:logback-spring.xml"},
+        classes = com.chessapp.api.codex.CodexApplication.class)
+@AutoConfigureMockMvc
+class MetricsControllerTest extends AbstractIntegrationTest {
+
+    @Autowired MockMvc mvc;
+    @MockBean ObsProxyClient obs;
+
+    private Map<String,Object> prom(double v) {
+        return Map.of("data", Map.of("result", List.of(Map.of("values", List.of(List.of(1, String.valueOf(v)))))));
+    }
+
+    @Test
+    void rps_ok() throws Exception {
+        when(obs.promRange(any(), any(Long.class), any(Long.class), any())).thenReturn(prom(1.0));
+        mvc.perform(get("/v1/metrics/rps").with(TestAuth.jwtUser()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.series[0].label").value("rps"));
+    }
+
+    @Test
+    void training_ok() throws Exception {
+        when(obs.promRange(any(), any(Long.class), any(Long.class), any())).thenReturn(prom(0.5));
+        mvc.perform(get("/v1/metrics/training/abc").param("m","loss,val_acc").with(TestAuth.jwtUser()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.series[0].label").value("loss"));
+    }
+}

--- a/api/api-app/src/test/java/com/chessapp/api/metrics/RangeHelperTest.java
+++ b/api/api-app/src/test/java/com/chessapp/api/metrics/RangeHelperTest.java
@@ -1,0 +1,15 @@
+package com.chessapp.api.metrics;
+
+import com.chessapp.api.metrics.service.RangeHelper;
+import com.chessapp.api.metrics.service.RangeParams;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class RangeHelperTest {
+    @Test
+    void mapRange() {
+        RangeParams p = RangeHelper.mapRange("2h");
+        assertTrue(p.end() > p.start());
+        assertEquals("60s", p.step());
+    }
+}

--- a/docs/API_ENDPOINTS.md
+++ b/docs/API_ENDPOINTS.md
@@ -67,6 +67,12 @@ Antwort:
 - `GET /v1/datasets`
 - `GET /v1/datasets/{id}`
 - `GET /v1/datasets/count`
+- `GET /v1/datasets/{id}/summary`
+- `GET /v1/datasets/{id}/versions`
+- `GET /v1/datasets/{id}/schema`
+- `GET /v1/datasets/{id}/sample`
+- `GET /v1/datasets/{id}/quality`
+- `GET /v1/datasets/{id}/ingest/history`
 
 ## Training
 
@@ -74,6 +80,8 @@ Antwort:
 - `GET /v1/trainings`
 - `GET /v1/trainings/count`
 - `GET /v1/trainings/{runId}`
+- `GET /v1/training/{runId}` (Alias)
+- `GET /v1/trainings/{runId}/artifacts`
 
 ## Serving/Play
 
@@ -95,6 +103,21 @@ Antwort:
 - `GET /v1/games/recent`
 - `GET /v1/games/online_count`
 - `POST /v1/games/demo`
+
+## Metrics
+
+- `GET /v1/metrics/throughput`
+- `GET /v1/metrics/training/{runId}`
+- `GET /v1/metrics/utilization`
+- `GET /v1/metrics/latency`
+- `GET /v1/metrics/mps`
+- `GET /v1/metrics/rps`
+- `GET /v1/metrics/error_rate`
+- `GET /v1/metrics/elo`
+
+## Logs
+
+- `GET /v1/logs/training/{runId}`
 
 ## Observability/Links
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -53,6 +53,20 @@ Siehe Grafana Panel *Ingest* (Prometheus).
 - `GET /obs/loki/query?query=`
 - `GET /obs/loki/query_range?query=...&start=&end=`
 
+## PromQL Beispiele
+
+```
+sum(rate(http_server_requests_seconds_count[1m]))                     # RPS
+increase(http_server_requests_seconds_count{status=~"5.."}[5m]) / increase(http_server_requests_seconds_count[5m])  # Error Rate
+histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket[5m]))) * 1000  # Latency
+avg_over_time(chs_training_it_per_sec{run_id="<ID>"}[5m])            # Throughput
+avg_over_time(ml_training_loss{run_id="<ID>"}[5m])                   # Loss
+avg_over_time(ml_training_val_acc{run_id="<ID>"}[5m])                # Val-Acc
+avg_over_time(chs_engine_elo[1h])                                     # ELO
+```
+
+Micrometer: `http_server_requests_seconds_*`
+
 ## Metrics SSOT
 The authoritative metric catalog is stored in `docs/observability/metrics.catalog.v1.yaml` (schema chessapp.metrics/1).
 Consumers (FE dashboards, BA/PL/SRE chats) should read from this file.

--- a/scripts/e2e_api_contracts.sh
+++ b/scripts/e2e_api_contracts.sh
@@ -121,4 +121,11 @@ grep -Eq "${HIST_PATTERN}" "$BODY" \
 rm -f "$BODY"
 ok "chs_* metrics present"
 
+hr; echo "[7] metrics & logs endpoints"
+curl -sf -H "Authorization: Bearer ${JWT_READ}" "${BASE_URL}/v1/metrics/rps?range=24h" | jq '.series' >/dev/null || fail "metrics rps"
+curl -sf -H "Authorization: Bearer ${JWT_READ}" "${BASE_URL}/v1/metrics/training/abc?m=loss,val_acc&range=24h" | jq '.series' >/dev/null || fail "metrics training"
+curl -sf -H "Authorization: Bearer ${JWT_READ}" "${BASE_URL}/v1/logs/training/abc" | jq '.items' >/dev/null || fail "logs training"
+curl -sf -H "Authorization: Bearer ${JWT_READ}" "${BASE_URL}/v1/datasets/abc/summary" | jq '.id' >/dev/null || fail "dataset summary"
+curl -sf -H "Authorization: Bearer ${JWT_READ}" "${BASE_URL}/v1/games/recent?limit=50" | jq '.[0]' >/dev/null || fail "games recent"
+
 hr; ok "E2E API CONTRACTS PASSED"


### PR DESCRIPTION
## Summary
- add metrics controller with throughput, training, rps, latency and more
- expose logs API for training runs
- stub dataset subresource endpoints and training alias

## Testing
- `mvn -q -f api/pom.xml -pl api-app -am -o test` *(fails: Non-resolvable parent POM)*
- `bash scripts/e2e_api_contracts.sh` *(fails: Health not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ea235500832b9148950069a7f8de