### PR TITLE
fix(metrics): correct throughput runId query escaping

### DIFF
--- a/api/api-app/src/main/java/com/chessapp/api/metrics/api/MetricsController.java
+++ b/api/api-app/src/main/java/com/chessapp/api/metrics/api/MetricsController.java
@@ -59,7 +59,7 @@ public class MetricsController {
         RangeParams rp = RangeHelper.mapRange(range);
         String q;
         if (runId != null) {
-            q = "avg_over_time(chs_training_it_per_sec{run_id=\\"" + runId + "\\"}[5m])";
+            q = "avg_over_time(chs_training_it_per_sec{run_id=\"" + runId + "\"}[5m])";
         } else {
             q = "sum(avg_over_time(chs_training_it_per_sec[5m]))";
         }


### PR DESCRIPTION
## Summary
- ensure run-specific throughput query escapes run_id label correctly

## Testing
- `mvn -f api/pom.xml -pl api-app -am test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f5558990832b98b42ab4f35e7ad3