### PR TITLE
feat: add Chess.com import endpoints

### DIFF
--- a/api/api-app/pom.xml
+++ b/api/api-app/pom.xml
@@ -124,6 +124,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+            <version>2.35.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
             <version>${flyway.version}</version>

--- a/api/api-app/src/main/java/com/chessapp/api/chesscom/api/ChessComController.java
+++ b/api/api-app/src/main/java/com/chessapp/api/chesscom/api/ChessComController.java
@@ -1,0 +1,99 @@
+package com.chessapp.api.chesscom.api;
+
+import com.chessapp.api.chesscom.api.dto.ArchiveMetaDto;
+import com.chessapp.api.chesscom.api.dto.ArchivesDto;
+import com.chessapp.api.chesscom.api.dto.ChessComIngestRequest;
+import com.chessapp.api.chesscom.api.dto.ChessComIngestResponse;
+import com.chessapp.api.chesscom.service.ChessComService;
+import com.chessapp.api.ingest.api.IngestController;
+import com.chessapp.api.ingest.api.dto.IngestStartResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.time.YearMonth;
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1")
+public class ChessComController {
+
+    private static final Logger log = LoggerFactory.getLogger(ChessComController.class);
+
+    private final ChessComService service;
+    private final IngestController ingestController;
+
+    public ChessComController(ChessComService service, IngestController ingestController) {
+        this.service = service;
+        this.ingestController = ingestController;
+    }
+
+    private static String validateUser(String user) {
+        if (user == null || !user.matches("[a-z0-9_-]+")) {
+            throw new org.springframework.web.server.ResponseStatusException(HttpStatus.BAD_REQUEST, "invalid user");
+        }
+        return user.toLowerCase();
+    }
+
+    @GetMapping("/chesscom/archives")
+    public ArchivesDto archives(@RequestParam("user") String user) {
+        String u = validateUser(user);
+        try {
+            return new ArchivesDto(service.listArchives(u));
+        } catch (WebClientResponseException ex) {
+            if (ex.getStatusCode() == HttpStatus.NOT_FOUND) {
+                throw new org.springframework.web.server.ResponseStatusException(HttpStatus.NOT_FOUND);
+            }
+            if (ex.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
+                throw new org.springframework.web.server.ResponseStatusException(HttpStatus.TOO_MANY_REQUESTS, "Bitte später erneut");
+            }
+            throw new org.springframework.web.server.ResponseStatusException(HttpStatus.BAD_GATEWAY);
+        }
+    }
+
+    @GetMapping("/chesscom/archive/meta")
+    public ArchiveMetaDto meta(@RequestParam("user") String user,
+                               @RequestParam("year") int year,
+                               @RequestParam("month") int month) {
+        String u = validateUser(user);
+        try {
+            ChessComService.ArchiveMeta meta = service.meta(u, year, month);
+            return new ArchiveMetaDto(meta.count(), meta.timeControlDist());
+        } catch (WebClientResponseException ex) {
+            if (ex.getStatusCode() == HttpStatus.NOT_FOUND) {
+                throw new org.springframework.web.server.ResponseStatusException(HttpStatus.NOT_FOUND);
+            }
+            if (ex.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
+                throw new org.springframework.web.server.ResponseStatusException(HttpStatus.TOO_MANY_REQUESTS, "Bitte später erneut");
+            }
+            throw new org.springframework.web.server.ResponseStatusException(HttpStatus.BAD_GATEWAY);
+        }
+    }
+
+    @PostMapping("/ingest/chesscom")
+    public ResponseEntity<ChessComIngestResponse> ingest(@RequestBody ChessComIngestRequest req) {
+        String u = validateUser(req.user());
+        List<String> months = req.months();
+        if (months == null || months.isEmpty()) {
+            throw new org.springframework.web.server.ResponseStatusException(HttpStatus.BAD_REQUEST, "months required");
+        }
+        String requester = SecurityContextHolder.getContext().getAuthentication().getName();
+        log.info("chesscom ingest requester={}, user={}, months={}, datasetId={}", requester, u, months, req.datasetId());
+        IngestStartResponse last = null;
+        for (String m : months) {
+            YearMonth ym = YearMonth.parse(m);
+            byte[] pgn = service.downloadPgn(u, ym);
+            MockMultipartFile file = new MockMultipartFile("file", u + "-" + m + ".pgn", "application/x-chess-pgn", pgn);
+            ResponseEntity<IngestStartResponse> resp = ingestController.start(file, req.datasetId(), req.note(), "v" + m);
+            last = resp.getBody();
+        }
+        String runId = last != null ? "ing_" + last.runId().toString() : "ing_unknown";
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new ChessComIngestResponse(runId, "queued"));
+    }
+}

--- a/api/api-app/src/main/java/com/chessapp/api/chesscom/api/dto/ArchiveMetaDto.java
+++ b/api/api-app/src/main/java/com/chessapp/api/chesscom/api/dto/ArchiveMetaDto.java
@@ -1,0 +1,5 @@
+package com.chessapp.api.chesscom.api.dto;
+
+import java.util.Map;
+
+public record ArchiveMetaDto(int count, Map<String, Integer> timeControlDist) {}

--- a/api/api-app/src/main/java/com/chessapp/api/chesscom/api/dto/ArchivesDto.java
+++ b/api/api-app/src/main/java/com/chessapp/api/chesscom/api/dto/ArchivesDto.java
@@ -1,0 +1,5 @@
+package com.chessapp.api.chesscom.api.dto;
+
+import java.util.List;
+
+public record ArchivesDto(List<String> months) {}

--- a/api/api-app/src/main/java/com/chessapp/api/chesscom/api/dto/ChessComIngestRequest.java
+++ b/api/api-app/src/main/java/com/chessapp/api/chesscom/api/dto/ChessComIngestRequest.java
@@ -1,0 +1,5 @@
+package com.chessapp.api.chesscom.api.dto;
+
+import java.util.List;
+
+public record ChessComIngestRequest(String user, List<String> months, String datasetId, String note) {}

--- a/api/api-app/src/main/java/com/chessapp/api/chesscom/api/dto/ChessComIngestResponse.java
+++ b/api/api-app/src/main/java/com/chessapp/api/chesscom/api/dto/ChessComIngestResponse.java
@@ -1,0 +1,3 @@
+package com.chessapp.api.chesscom.api.dto;
+
+public record ChessComIngestResponse(String runId, String status) {}

--- a/api/api-app/src/main/java/com/chessapp/api/chesscom/service/ChessComService.java
+++ b/api/api-app/src/main/java/com/chessapp/api/chesscom/service/ChessComService.java
@@ -1,0 +1,101 @@
+package com.chessapp.api.chesscom.service;
+
+import java.time.Duration;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import reactor.netty.http.client.HttpClient;
+import reactor.util.retry.Retry;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+
+@Service
+public class ChessComService {
+
+    private final WebClient web;
+    private final Map<String, Long> nextAllowed = new ConcurrentHashMap<>();
+
+    public ChessComService(@Value("${chess.ingest.baseUrl:https://api.chess.com}") String baseUrl) {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
+                .responseTimeout(Duration.ofSeconds(15))
+                .doOnConnected(conn -> conn
+                        .addHandlerLast(new ReadTimeoutHandler(15))
+                        .addHandlerLast(new WriteTimeoutHandler(15)));
+
+        Retry retrySpec = Retry.max(2)
+                .filter(t -> t instanceof WebClientResponseException ex && ex.getStatusCode().is5xxServerError());
+
+        this.web = WebClient.builder()
+                .baseUrl(baseUrl)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .filter((request, next) -> next.exchange(request).retryWhen(retrySpec))
+                .build();
+    }
+
+    private void throttle(String user) {
+        user = user.toLowerCase();
+        long now = System.currentTimeMillis();
+        long allowed = nextAllowed.getOrDefault(user, 0L);
+        if (now < allowed) {
+            try { Thread.sleep(allowed - now); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+        }
+        nextAllowed.put(user, System.currentTimeMillis() + 1000);
+    }
+
+    public List<String> listArchives(String user) {
+        throttle(user);
+        ArchivesWrapper wrapper = web.get()
+                .uri("/pub/player/{user}/games/archives", user)
+                .retrieve()
+                .bodyToMono(ArchivesWrapper.class)
+                .block();
+        return wrapper.archives().stream()
+                .map(url -> {
+                    String[] parts = url.split("/");
+                    String year = parts[parts.length - 2];
+                    String month = parts[parts.length - 1];
+                    return year + "-" + month;
+                })
+                .collect(Collectors.toList());
+    }
+
+    public ArchiveMeta meta(String user, int year, int month) {
+        throttle(user);
+        GamesWrapper wrapper = web.get()
+                .uri("/pub/player/{user}/games/{year}/{month}", user, year, String.format("%02d", month))
+                .retrieve()
+                .bodyToMono(GamesWrapper.class)
+                .block();
+        int count = wrapper.games() == null ? 0 : wrapper.games().size();
+        Map<String, Integer> dist = wrapper.games() == null ? Map.of() :
+                wrapper.games().stream()
+                        .collect(Collectors.groupingBy(Game::time_class, Collectors.summingInt(g -> 1)));
+        return new ArchiveMeta(count, dist);
+    }
+
+    public byte[] downloadPgn(String user, YearMonth ym) {
+        throttle(user);
+        return web.get()
+                .uri("/pub/player/{user}/games/{year}/{month}/pgn", user, ym.getYear(), String.format("%02d", ym.getMonthValue()))
+                .retrieve()
+                .bodyToMono(byte[].class)
+                .block();
+    }
+
+    private record ArchivesWrapper(List<String> archives) {}
+    private record GamesWrapper(List<Game> games) {}
+    private record Game(String time_class) {}
+
+    public record ArchiveMeta(int count, Map<String, Integer> timeControlDist) {}
+}

--- a/api/api-app/src/test/java/com/chessapp/api/chesscom/ChessComControllerTest.java
+++ b/api/api-app/src/test/java/com/chessapp/api/chesscom/ChessComControllerTest.java
@@ -1,0 +1,64 @@
+package com.chessapp.api.chesscom;
+
+import com.chessapp.api.codex.CodexApplication;
+import com.chessapp.api.testutil.TestAuth;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(properties = {"chess.ingest.baseUrl=http://localhost:${wiremock.server.port}"},
+        classes = CodexApplication.class)
+@AutoConfigureMockMvc
+@WireMockTest(httpPort = 0)
+class ChessComControllerTest {
+
+    @Autowired MockMvc mvc;
+
+    @Test
+    void archives_ok() throws Exception {
+        stubFor(get(urlEqualTo("/pub/player/testuser/games/archives"))
+                .willReturn(okJson("{\"archives\":[\"http://x/pub/player/testuser/games/2024/01\"]}")));
+        mvc.perform(get("/v1/chesscom/archives").param("user","testuser").with(TestAuth.jwtUser()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.months[0]").value("2024-01"));
+    }
+
+    @Test
+    void archives_404() throws Exception {
+        stubFor(get(urlEqualTo("/pub/player/unknown/games/archives"))
+                .willReturn(aResponse().withStatus(404)));
+        mvc.perform(get("/v1/chesscom/archives").param("user","unknown").with(TestAuth.jwtUser()))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void meta_ok() throws Exception {
+        stubFor(get(urlEqualTo("/pub/player/testuser/games/2024/01"))
+                .willReturn(okJson("{\"games\":[{\"time_class\":\"rapid\"},{\"time_class\":\"blitz\"}]}")));
+        mvc.perform(get("/v1/chesscom/archive/meta")
+                .param("user","testuser").param("year","2024").param("month","1")
+                .with(TestAuth.jwtUser()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.count").value(2))
+                .andExpect(jsonPath("$.timeControlDist.rapid").value(1));
+    }
+
+    @Test
+    void ingest_ok() throws Exception {
+        stubFor(get(urlEqualTo("/pub/player/testuser/games/2024/01/pgn"))
+                .willReturn(ok("pgn")));
+        String body = "{\"user\":\"testuser\",\"months\":[\"2024-01\"],\"datasetId\":null,\"note\":null}";
+        mvc.perform(post("/v1/ingest/chesscom").with(TestAuth.jwtUser())
+                .contentType(MediaType.APPLICATION_JSON).content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.runId").exists());
+    }
+}

--- a/docs/API_ENDPOINTS.md
+++ b/docs/API_ENDPOINTS.md
@@ -156,6 +156,29 @@ Antwort 201:
 - `GET /v1/games/online_count`
 - `POST /v1/games/demo`
 
+## Chess.com Import
+
+- `GET /v1/chesscom/archives?user={username}` → `{ "months": ["2024-01", ...] }`
+- `GET /v1/chesscom/archive/meta?user={u}&year=YYYY&month=MM` → `{ "count": 10, "timeControlDist": { "rapid": 5, "blitz": 5 } }`
+- `POST /v1/ingest/chesscom`
+
+Beispiel:
+
+```json
+{
+  "user": "magnuscarlsen",
+  "months": ["2024-01"],
+  "datasetId": "<UUID>",
+  "note": "optional"
+}
+```
+
+Antwort 201:
+
+```json
+{ "runId": "ing_<uuid>", "status": "queued" }
+```
+
 ## Metrics
 
 - `GET /v1/metrics/throughput`


### PR DESCRIPTION
## Summary
- bridge Chess.com archives via new `/v1/chesscom/**` endpoints
- allow Chess.com PGN import through `/v1/ingest/chesscom`
- document Chess.com import APIs

## Testing
- `mvn -q -pl api-app -am test -f api/pom.xml` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1b1d75f4832b9a3c5d116d363044